### PR TITLE
Bugfixes

### DIFF
--- a/app/init.js
+++ b/app/init.js
@@ -25,6 +25,12 @@ async function init() {
         btnAddCardToList.click();
     });
     document.addEventListener('click', async (e) => {
+        if (e.target.offsetParent && e.target.offsetParent.className && e.target.offsetParent.className == 'overtype-preview' && e.target.tagName === "A") {
+            e.preventDefault();
+            window.electronAPI.openExternal(e.target.href);
+            return;
+        }
+
         await closeAllModals(e);
     });
     document.getElementById('btnAddNewList').addEventListener('click', async () => {

--- a/app/modals/closeAllModals.js
+++ b/app/modals/closeAllModals.js
@@ -13,8 +13,8 @@ async function closeAllModals(e){
             modalEditCard.style.display = 'none';
             const cardEditorTitle = document.getElementById('cardEditorTitle');
             OverType.destroyAll();
-            const cardEditorContents = document.getElementById('cardEditorOverType');
-            cardEditorContents.value = '';
+            const cardEditorContents = document.getElementsByClassName('overtype-input');
+            cardEditorContents[0].value = '';
             cardEditorTitle.textContent = '';
             document.getElementById('board').style = 'filter: none';
         }
@@ -35,8 +35,8 @@ async function closeAllModals(e){
             modalEditCard.style.display = 'none';
             const cardEditorTitle = document.getElementById('cardEditorTitle');
             OverType.destroyAll();
-            const cardEditorContents = document.getElementById('cardEditorOverType');
-            cardEditorContents.value = '';
+            const cardEditorContents = document.getElementsByClassName('overtype-input');
+            cardEditorContents[0].value = '';
             cardEditorTitle.textContent = '';
             document.getElementById('board').style = 'filter: none';
         }

--- a/app/utilities/santizeFileName.js
+++ b/app/utilities/santizeFileName.js
@@ -23,7 +23,7 @@ async function sanitizeFileName(rawName) {
   const finalBase = truncatedBase.replace(/[ .]+$/g, '');
 
   // 5. Return combined result
-  const finalName = finalBase.slice(0,25) + ext;
+  const finalName = finalBase + ext;
   return finalName || '999-untitled.md'; // fallback if everything was stripped
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "signboard",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signboard",
   "productName": "Signboard",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "author": "Colin Devroe - cdevroe.com",
   "main": "main.js",

--- a/preload.js
+++ b/preload.js
@@ -154,6 +154,10 @@ contextBridge.exposeInMainWorld('chooser', {
   pickDirectory: (opts = {}) => ipcRenderer.invoke('choose-directory', opts),
 });
 
+contextBridge.exposeInMainWorld("electronAPI", {
+  openExternal: (url) => shell.openExternal(url),
+});
+
 // Remove characters that are not allowed in filenames
 function sanitize(str) {
   return str.replace(/[<>:"/\\|?*\x00-\x1F]/g, '').trim() || 'untitled';

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Signboard
 
-A local-first kanban-style desktop app built with a web stack. Signboard stores your lists as directories and cards as Markdown files on disk, so you own your data. Built with as few dependencies as possible 😅, it’s lightweight, transparent, and open source.
+A local-first kanban desktop app built with HTML, CSS, and plain JavaScript. Signboard stores your lists as directories and cards as Markdown files on disk, so you own your data.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/cdevroe/signboard)](../../issues)


### PR DESCRIPTION
- Added OverType as a Markdown editor for Card notes
- This brings links, unordered and ordered lists, heading, etc. to Signboard
- OverType has two custom themes in Signboard for Light and Dark mode
- Click CardID in card edit modal to open file explorer to Markdown file
- Bug fixes