### PR TITLE
Version 1.1.0

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -28,5 +28,8 @@ Start here before opening source files.
 - Skill UI metadata lives at `skills/signboard-mcp/agents/openai.yaml`.
 - Board tabs/session state live in renderer localStorage: `boardTabs` (open tab order) and `boardPath` (active board root fallback).
 - Board label definitions are managed in `board-settings.md` files inside each board folder (runtime data, not repo source).
+- Board Settings now includes an `Import` panel that launches explicit Trello/Obsidian imports into the current board; the renderer wiring lives in `app/board/boardLabels.js`, while the actual import filesystem work lives in `lib/importers/*` through `main.js` IPC.
+- External import pickers are tokenized in `main.js` and surfaced through `window.chooser.pickImportSources(...)`; renderer code never reads arbitrary external files directly.
+- Trello and Obsidian importer coverage lives in `scripts/test-import-trello.js` and `scripts/test-import-obsidian.js`.
 - Skip heavy/generated content unless explicitly needed: `node_modules/`, `dist/`, `static/vendor/`, and usually `package-lock.json`.
 - Always update Codex markdown docs when behavior/architecture/tooling changes (`CODEX.md`, `docs/codex/PROJECT_CONTEXT.md`, `docs/codex/FILE_STRUCTURE.md`).

--- a/CODEX.md
+++ b/CODEX.md
@@ -8,7 +8,7 @@ Start here before opening source files.
 - Tooltip UI is implemented in `app/ui/tooltips.js` and reads existing control labels (`title` / `aria-label` / `alt`) to keep tooltip copy centralized in markup.
 - App updates are handled in `main.js` via `electron-updater` (GitHub releases), with menu-triggered/manual checks and remind-later state in `update-preferences.json` under Electron `userData`.
 - `main.js` also supports headless MCP mode via `--mcp-server` for local agent integration over stdio; implementation lives in `lib/mcpServer.js`.
-- Signboard MCP includes board-name resolution (`signboard.resolve_board_by_name`) and supports both header-framed + newline-delimited stdio JSON-RPC.
+- Signboard MCP includes board-name resolution (`signboard.resolve_board_by_name`), Trello/Obsidian import tools, and supports both header-framed + newline-delimited stdio JSON-RPC.
 - Main window stability guards are in `main.js` (`unresponsive` dialog + renderer crash recovery window recreate).
 - `main.js` supports `--mcp-config` to print a ready-to-paste MCP config JSON snippet and exit.
 - `Help` menu includes `Copy MCP Config`, which copies a ready-to-paste MCP server config snippet to clipboard.
@@ -31,5 +31,6 @@ Start here before opening source files.
 - Board Settings now includes an `Import` panel that launches explicit Trello/Obsidian imports into the current board; the renderer wiring lives in `app/board/boardLabels.js`, while the actual import filesystem work lives in `lib/importers/*` through `main.js` IPC.
 - External import pickers are tokenized in `main.js` and surfaced through `window.chooser.pickImportSources(...)`; renderer code never reads arbitrary external files directly.
 - Trello and Obsidian importer coverage lives in `scripts/test-import-trello.js` and `scripts/test-import-obsidian.js`.
+- The terminal CLI now exposes `signboard import trello --file ...` and `signboard import obsidian --source ...`; MCP mirrors that with `signboard.import_trello` and `signboard.import_obsidian`.
 - Skip heavy/generated content unless explicitly needed: `node_modules/`, `dist/`, `static/vendor/`, and usually `package-lock.json`.
 - Always update Codex markdown docs when behavior/architecture/tooling changes (`CODEX.md`, `docs/codex/PROJECT_CONTEXT.md`, `docs/codex/FILE_STRUCTURE.md`).

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -23,6 +23,7 @@ By default, the server starts in read-only mode.
   - optional allowlist of board root parent directories
   - uses your OS path delimiter (`:` on macOS/Linux, `;` on Windows)
   - when set, `boardRoot` arguments must resolve inside one of these paths
+  - import tool `sourcePath` / `sourcePaths` arguments must also resolve inside one of these paths
 
 Example (macOS/Linux):
 
@@ -106,9 +107,12 @@ The server currently exposes these tools:
 - `signboard.move_board` (write mode only)
 - `signboard.read_board_settings`
 - `signboard.update_board_settings` (write mode only)
+- `signboard.import_trello` (write mode only)
+- `signboard.import_obsidian` (write mode only)
 
 Board-scoped tools take absolute `boardRoot` paths, `signboard.create_board` takes an absolute `parentRoot`, and all path inputs reject traversal.
 Board settings tools include labels, theme overrides, and notification preferences.
+Import tools also take absolute external source paths and honor `SIGNBOARD_MCP_ALLOWED_ROOTS` when it is configured.
 
 ## Task Metadata in Card Tool Responses
 
@@ -194,4 +198,5 @@ If `SIGNBOARD_MCP_ALLOWED_ROOTS` is not set, the resolver tool returns an error.
 - Card reads/writes use Signboard's existing frontmatter logic (`lib/cardFrontmatter.js`).
 - `signboard.create_card` and `signboard.update_card` normalize literal `\n` / `\N` escape sequences in body input into real line breaks.
 - Board settings use Signboard's existing settings logic (`lib/boardLabels.js`).
+- Trello/Obsidian import tools reuse the same importer modules as the desktop app (`lib/importers/*`).
 - When the desktop app is open, external board edits (including MCP edits) are watched and auto-refreshed.

--- a/app/board/boardLabels.js
+++ b/app/board/boardLabels.js
@@ -66,6 +66,7 @@ const DEFAULT_BOARD_NOTIFICATION_SETTINGS = Object.freeze({
   time: '09:00',
 });
 const DEFAULT_BOARD_TOOLTIPS_ENABLED = true;
+const BOARD_IMPORT_TEST_OVERRIDE_KEY = '__signboardImportOverrides';
 
 function clampNumber(value, min, max) {
   return Math.min(max, Math.max(min, value));
@@ -430,6 +431,9 @@ function getBoardLabelState() {
       notificationSettings: { ...DEFAULT_BOARD_NOTIFICATION_SETTINGS },
       tooltipsEnabled: DEFAULT_BOARD_TOOLTIPS_ENABLED,
       activeSettingsPanel: 'general',
+      importInProgress: '',
+      importSummary: null,
+      importSummaryBoardRoot: '',
       settingsSaveTimer: null,
       settingsSaveInFlight: Promise.resolve(),
     };
@@ -1467,7 +1471,7 @@ function renderBoardSettingsPanelState() {
 }
 
 function setActiveBoardSettingsPanel(panelId) {
-  const normalizedPanelId = ['general', 'labels', 'colors', 'notifications'].includes(panelId)
+  const normalizedPanelId = ['general', 'labels', 'colors', 'notifications', 'import'].includes(panelId)
     ? panelId
     : 'general';
   const state = getBoardLabelState();
@@ -1505,6 +1509,167 @@ function renderNotificationSettingsControls() {
 
   if (notificationsTimeInput) {
     notificationsTimeInput.value = notifications.time;
+  }
+}
+
+function formatImportSummaryText(summary) {
+  if (!summary || typeof summary !== 'object') {
+    return '';
+  }
+
+  const sources = Array.isArray(summary.sources) ? summary.sources.length : 0;
+  const parts = [
+    `Imported ${sources === 1 ? '1 source' : `${sources} sources`}.`,
+    `${summary.listsCreated || 0} list${summary.listsCreated === 1 ? '' : 's'} created.`,
+    `${summary.cardsCreated || 0} card${summary.cardsCreated === 1 ? '' : 's'} created.`,
+  ];
+
+  if ((summary.labelsCreated || 0) > 0) {
+    parts.push(`${summary.labelsCreated} label${summary.labelsCreated === 1 ? '' : 's'} created.`);
+  }
+
+  if ((summary.archivedCards || 0) > 0) {
+    parts.push(`${summary.archivedCards} archived.`);
+  }
+
+  return parts.join(' ');
+}
+
+function getBoardImportOverrides() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const overrides = window[BOARD_IMPORT_TEST_OVERRIDE_KEY];
+  return overrides && typeof overrides === 'object' ? overrides : null;
+}
+
+function getBoardImportPicker() {
+  const overrides = getBoardImportOverrides();
+  if (overrides && typeof overrides.pickImportSources === 'function') {
+    return overrides.pickImportSources;
+  }
+
+  return window.chooser && typeof window.chooser.pickImportSources === 'function'
+    ? window.chooser.pickImportSources
+    : null;
+}
+
+function getBoardImportRunner(importer) {
+  const overrides = getBoardImportOverrides();
+  const overrideKey = importer === 'trello' ? 'importTrello' : 'importObsidian';
+  if (overrides && typeof overrides[overrideKey] === 'function') {
+    return overrides[overrideKey];
+  }
+
+  if (!window.board) {
+    return null;
+  }
+
+  const defaultRunner = importer === 'trello' ? window.board.importTrello : window.board.importObsidian;
+  return typeof defaultRunner === 'function' ? defaultRunner : null;
+}
+
+function renderBoardImportControls() {
+  const state = getBoardLabelState();
+  const trelloButton = document.getElementById('btnImportBoardFromTrello');
+  const obsidianButton = document.getElementById('btnImportBoardFromObsidian');
+  const status = document.getElementById('boardSettingsImportStatus');
+  const warnings = document.getElementById('boardSettingsImportWarnings');
+  const isBusy = Boolean(state.importInProgress);
+  const canImport = Boolean(window.boardRoot) && !isBusy;
+  const currentBoardRoot = normalizeBoardPath(window.boardRoot);
+  const summaryBoardRoot = normalizeBoardPath(state.importSummaryBoardRoot);
+  const hasVisibleSummary = Boolean(state.importSummary) && summaryBoardRoot === currentBoardRoot;
+
+  if (trelloButton) {
+    trelloButton.disabled = !canImport;
+    trelloButton.textContent = state.importInProgress === 'trello' ? 'Importing Trello' : 'Import from Trello';
+  }
+
+  if (obsidianButton) {
+    obsidianButton.disabled = !canImport;
+    obsidianButton.textContent = state.importInProgress === 'obsidian' ? 'Importing Obsidian' : 'Import from Obsidian';
+  }
+
+  if (status) {
+    status.classList.toggle('hidden', !hasVisibleSummary);
+    status.textContent = hasVisibleSummary ? formatImportSummaryText(state.importSummary) : '';
+  }
+
+  if (warnings) {
+    warnings.innerHTML = '';
+    const warningMessages = hasVisibleSummary && Array.isArray(state.importSummary.warnings)
+      ? state.importSummary.warnings
+      : [];
+
+    warnings.classList.toggle('hidden', warningMessages.length === 0);
+    for (const warningMessage of warningMessages) {
+      const message = document.createElement('p');
+      message.textContent = warningMessage;
+      warnings.appendChild(message);
+    }
+  }
+}
+
+async function runBoardImport(importer) {
+  const state = getBoardLabelState();
+  if (!window.boardRoot || state.importInProgress) {
+    return;
+  }
+
+  const pickImportSources = getBoardImportPicker();
+  const runImporter = getBoardImportRunner(importer);
+  if (!pickImportSources || !runImporter) {
+    return;
+  }
+
+  const boardInfo = getBoardRootInfo();
+  const defaultPath = boardInfo ? boardInfo.parentRoot.replace(/\/+$/, '') : undefined;
+
+  await flushBoardSettingsSave();
+  state.importInProgress = importer;
+  renderBoardImportControls();
+
+  let shouldRefreshBoard = false;
+
+  try {
+    const selections = await pickImportSources({ importer, defaultPath });
+    if (!Array.isArray(selections) || selections.length === 0) {
+      return;
+    }
+
+    let summary = null;
+    if (importer === 'trello') {
+      summary = await runImporter(window.boardRoot, selections[0].token);
+    } else {
+      summary = await runImporter(window.boardRoot, selections.map((selection) => selection.token));
+    }
+
+    state.importSummary = summary;
+    state.importSummaryBoardRoot = normalizeBoardPath(window.boardRoot);
+    shouldRefreshBoard = true;
+  } catch (error) {
+    console.error(`Unable to import from ${importer}.`, error);
+    if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+      window.alert(`Unable to import from ${importer}.\n\n${String(error?.message || error || 'Unknown error')}`);
+    }
+  } finally {
+    state.importInProgress = '';
+    renderBoardImportControls();
+  }
+
+  if (shouldRefreshBoard) {
+    Promise.allSettled([
+      ensureBoardLabelsLoaded(),
+      renderBoard(),
+    ]).then((results) => {
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          console.error(`Unable to refresh the board after importing from ${importer}.`, result.reason);
+        }
+      }
+    });
   }
 }
 
@@ -1572,6 +1737,7 @@ function openBoardSettingsModal() {
   renderBoardThemeSettingsControls();
   renderBoardGeneralSettingsControls();
   renderNotificationSettingsControls();
+  renderBoardImportControls();
   setActiveBoardSettingsPanel('general');
   modal.style.display = 'block';
 
@@ -1607,6 +1773,8 @@ function resetBoardLabelFilter() {
 
 async function ensureBoardLabelsLoaded() {
   if (!window.boardRoot) {
+    const state = getBoardLabelState();
+    state.importSummaryBoardRoot = '';
     setBoardLabels([]);
     applyDerivedBoardThemes({ light: {}, dark: {} }, { renderControls: false });
     setBoardNotificationSettings(DEFAULT_BOARD_NOTIFICATION_SETTINGS);
@@ -1616,6 +1784,7 @@ async function ensureBoardLabelsLoaded() {
     renderBoardThemeSettingsControls();
     renderBoardGeneralSettingsControls();
     renderNotificationSettingsControls();
+    renderBoardImportControls();
     return;
   }
 
@@ -1629,6 +1798,7 @@ async function ensureBoardLabelsLoaded() {
   renderBoardThemeSettingsControls();
   renderBoardGeneralSettingsControls();
   renderNotificationSettingsControls();
+  renderBoardImportControls();
 }
 
 function closeAllLabelPopovers() {
@@ -1659,6 +1829,8 @@ function initializeBoardLabelControls() {
   const notificationsTimeInput = document.getElementById('boardSettingsNotificationsTime');
   const applyNotificationsToOpenBoardsButton = document.getElementById('btnApplyNotificationsToOpenBoards');
   const tooltipsToggle = document.getElementById('boardSettingsTooltipsToggle');
+  const importFromTrelloButton = document.getElementById('btnImportBoardFromTrello');
+  const importFromObsidianButton = document.getElementById('btnImportBoardFromObsidian');
 
   if (filterButton) {
     filterButton.addEventListener('click', (event) => {
@@ -1889,5 +2061,22 @@ function initializeBoardLabelControls() {
     });
   }
 
+  if (importFromTrelloButton) {
+    importFromTrelloButton.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      await runBoardImport('trello');
+    });
+  }
+
+  if (importFromObsidianButton) {
+    importFromObsidianButton.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      await runBoardImport('obsidian');
+    });
+  }
+
   renderBoardSettingsPanelState();
+  renderBoardImportControls();
 }

--- a/app/board/boardLabels.js
+++ b/app/board/boardLabels.js
@@ -961,6 +961,9 @@ function toggleCardLabelSelector(anchorElement, cardPath, selectedLabelIds, onCh
 
   closeBoardLabelFilterPopover();
   closeCardLabelPopover();
+  if (typeof closeListActionsPopover === 'function') {
+    closeListActionsPopover();
+  }
 
   const menu = document.createElement('div');
   menu.className = 'label-popover card-label-popover';
@@ -1807,6 +1810,9 @@ function closeAllLabelPopovers() {
   if (typeof closeBoardViewPopover === 'function') {
     closeBoardViewPopover();
   }
+  if (typeof closeListActionsPopover === 'function') {
+    closeListActionsPopover();
+  }
 }
 
 function initializeBoardLabelControls() {
@@ -1842,6 +1848,9 @@ function initializeBoardLabelControls() {
       closeCardLabelPopover();
       if (typeof closeBoardViewPopover === 'function') {
         closeBoardViewPopover();
+      }
+      if (typeof closeListActionsPopover === 'function') {
+        closeListActionsPopover();
       }
       renderBoardLabelFilterPopover();
       const isHidden = filterPopover.classList.contains('hidden');

--- a/app/board/boardLabels.js
+++ b/app/board/boardLabels.js
@@ -61,6 +61,201 @@ const BOARD_THEME_STYLE_VAR_MAP = Object.freeze({
     shadowCard: '--sb-dark-shadow-card',
   }),
 });
+/* ──────────────────────────────────────────────────────────────────────────────
+ * COLOR SCHEMES
+ *
+ * Each scheme provides a full light AND dark palette so the light/dark toggle
+ * continues to work.  To tweak a scheme, edit the hex values below — every
+ * palette key maps directly to a CSS custom property via BOARD_THEME_STYLE_VAR_MAP.
+ *
+ * Palette keys:
+ *   boardBackground  – page / board background
+ *   surface          – card / elevated surface
+ *   text             – primary text
+ *   muted            – secondary / hint text
+ *   border           – borders & dividers
+ *   accent           – buttons, links, focus rings
+ *   accentText       – text rendered ON the accent color
+ *   shadow           – subtle drop shadow
+ *   shadowCard       – slightly stronger card shadow
+ * ────────────────────────────────────────────────────────────────────────── */
+const COLOR_SCHEMES = [
+  {
+    id: 'default',
+    name: 'Default',
+    light: {
+      boardBackground: '#f7f8fa',
+      surface:         '#ffffff',
+      text:            '#0f172a',
+      muted:           '#6b7280',
+      border:          '#e6e8ec',
+      accent:          '#0b5fff',
+      accentText:      '#ffffff',
+      shadow:          'rgba(15, 23, 42, .04)',
+      shadowCard:      'rgba(15, 23, 42, .06)',
+    },
+    dark: {
+      boardBackground: '#091102',
+      surface:         '#12200a',
+      text:            '#e8f0e5',
+      muted:           '#a0b3a3',
+      border:          '#1f2e17',
+      accent:          '#6fcf97',
+      accentText:      '#07130c',
+      shadow:          'rgba(0, 0, 0, 0.45)',
+      shadowCard:      'rgba(0, 0, 0, 0.55)',
+    },
+  },
+
+  /* ── Meadow  ─  palette #EAF7CF · #EBEFBF · #CEB5A7 · #92828D · #ADAABF ─ */
+  {
+    id: 'lavender',
+    name: 'Lavender',
+    light: {
+      boardBackground: '#f2f5ec',
+      surface:         '#fafbf7',
+      text:            '#2b2833',
+      muted:           '#706878',
+      border:          '#dddbd3',
+      accent:          '#7b6e8a',
+      accentText:      '#ffffff',
+      shadow:          'rgba(43, 40, 51, 0.05)',
+      shadowCard:      'rgba(43, 40, 51, 0.08)',
+    },
+    dark: {
+      boardBackground: '#1e1b24',
+      surface:         '#292631',
+      text:            '#e6eed5',
+      muted:           '#a29dae',
+      border:          '#3a3644',
+      accent:          '#c4bdd2',
+      accentText:      '#1e1b24',
+      shadow:          'rgba(0, 0, 0, 0.40)',
+      shadowCard:      'rgba(0, 0, 0, 0.50)',
+    },
+  },
+
+  /* ── Harvest  ─  palette #F9A03F · #F7D488 · #EAEFB1 · #E9F7CA · #CEB5A7 ─ */
+  {
+    id: 'harvest',
+    name: 'Harvest',
+    light: {
+      boardBackground: '#f6f2e8',
+      surface:         '#fcfaf4',
+      text:            '#33280f',
+      muted:           '#8a7b62',
+      border:          '#e5dece',
+      accent:          '#c4850a',
+      accentText:      '#ffffff',
+      shadow:          'rgba(51, 40, 15, 0.05)',
+      shadowCard:      'rgba(51, 40, 15, 0.08)',
+    },
+    dark: {
+      boardBackground: '#1c1709',
+      surface:         '#282012',
+      text:            '#f0eacd',
+      muted:           '#b5a67f',
+      border:          '#3b3220',
+      accent:          '#f9a03f',
+      accentText:      '#1c1709',
+      shadow:          'rgba(0, 0, 0, 0.40)',
+      shadowCard:      'rgba(0, 0, 0, 0.50)',
+    },
+  },
+
+  /* ── Olive  ─  palette #606C38 · #283618 · #FEFAE0 · #DDA15E · #BC6C25 ── */
+  {
+    id: 'olive',
+    name: 'Olive',
+    light: {
+      boardBackground: '#faf6dc',
+      surface:         '#fefcee',
+      text:            '#283618',
+      muted:           '#6b6543',
+      border:          '#e4ddb8',
+      accent:          '#5d6832',
+      accentText:      '#fefae0',
+      shadow:          'rgba(40, 54, 24, 0.06)',
+      shadowCard:      'rgba(40, 54, 24, 0.09)',
+    },
+    dark: {
+      boardBackground: '#161e0c',
+      surface:         '#212a14',
+      text:            '#f3efd2',
+      muted:           '#a39e72',
+      border:          '#303a1f',
+      accent:          '#dda15e',
+      accentText:      '#161e0c',
+      shadow:          'rgba(0, 0, 0, 0.45)',
+      shadowCard:      'rgba(0, 0, 0, 0.55)',
+    },
+  },
+
+  /* ── Evergreen  ─  palette #DAD7CD · #A3B18A · #588157 · #3A5A40 · #344E41 */
+  {
+    id: 'evergreen',
+    name: 'Evergreen',
+    light: {
+      boardBackground: '#e8e5dc',
+      surface:         '#f2f0ea',
+      text:            '#1e2f22',
+      muted:           '#5c6e5e',
+      border:          '#cbc7ba',
+      accent:          '#4e7550',
+      accentText:      '#ffffff',
+      shadow:          'rgba(30, 47, 34, 0.06)',
+      shadowCard:      'rgba(30, 47, 34, 0.09)',
+    },
+    dark: {
+      boardBackground: '#1a2620',
+      surface:         '#243029',
+      text:            '#dad7cd',
+      muted:           '#8da18a',
+      border:          '#2f3e34',
+      accent:          '#a3b18a',
+      accentText:      '#1a2620',
+      shadow:          'rgba(0, 0, 0, 0.45)',
+      shadowCard:      'rgba(0, 0, 0, 0.55)',
+    },
+  },
+
+  /* ── Rosewood  ─  palette #EDAFB8 · #F7E1D7 · #DEDBD2 · #B0C4B1 · #4A5759 */
+  {
+    id: 'rosewood',
+    name: 'Rosewood',
+    light: {
+      boardBackground: '#f3ece6',
+      surface:         '#faf7f4',
+      text:            '#2e3435',
+      muted:           '#6d7879',
+      border:          '#ddd7cf',
+      accent:          '#b5707c',
+      accentText:      '#ffffff',
+      shadow:          'rgba(46, 52, 53, 0.05)',
+      shadowCard:      'rgba(46, 52, 53, 0.08)',
+    },
+    dark: {
+      boardBackground: '#1e2526',
+      surface:         '#292f30',
+      text:            '#f0e4da',
+      muted:           '#97a69a',
+      border:          '#383f40',
+      accent:          '#edafb8',
+      accentText:      '#1e2526',
+      shadow:          'rgba(0, 0, 0, 0.40)',
+      shadowCard:      'rgba(0, 0, 0, 0.50)',
+    },
+  },
+];
+
+function getColorSchemeById(id) {
+  return COLOR_SCHEMES.find((scheme) => scheme.id === id) || null;
+}
+
+function getDefaultColorScheme() {
+  return COLOR_SCHEMES[0];
+}
+
 const DEFAULT_BOARD_NOTIFICATION_SETTINGS = Object.freeze({
   enabled: false,
   time: '09:00',
@@ -423,6 +618,7 @@ function getBoardLabelState() {
       filterIds: [],
       hasDueDateFilter: false,
       activeCardLabelPopover: null,
+      colorScheme: '',
       themeOverrides: { light: {}, dark: {} },
       themePalettes: {
         light: { ...DEFAULT_BOARD_THEME_PALETTES.light },
@@ -467,6 +663,15 @@ function getBoardThemeMode() {
   return document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
 }
 
+function getBoardColorScheme() {
+  return getBoardLabelState().colorScheme || '';
+}
+
+function setBoardColorScheme(schemeId) {
+  const state = getBoardLabelState();
+  state.colorScheme = typeof schemeId === 'string' ? schemeId : '';
+}
+
 function getBoardThemeOverrides() {
   const state = getBoardLabelState();
   return normalizeThemeOverrides(state.themeOverrides);
@@ -508,32 +713,7 @@ function getBoardThemePalettes() {
   };
 }
 
-function getBoardThemeOverrideBackground(themeMode) {
-  const overrides = getBoardThemeOverrides();
-  const modeOverrides = overrides[themeMode] || {};
-  return normalizeHexColor(modeOverrides.boardBackground, '');
-}
 
-function getEffectiveBoardThemeBackground(themeMode) {
-  const override = getBoardThemeOverrideBackground(themeMode);
-  return override || DEFAULT_BOARD_THEME_BACKGROUNDS[themeMode];
-}
-
-function createThemeWarningMessage(themeMode, palette) {
-  if (!palette) {
-    return '';
-  }
-
-  if (palette.textContrastRatio < 4.5) {
-    return `${themeMode === 'dark' ? 'Dark' : 'Light'} theme was adjusted to keep text readable.`;
-  }
-
-  if (palette.adjustedForReadability) {
-    return `${themeMode === 'dark' ? 'Dark' : 'Light'} theme colors were auto-adjusted for readability.`;
-  }
-
-  return '';
-}
 
 function applyThemePaletteVariables(themeMode, palette) {
   const modeMap = BOARD_THEME_STYLE_VAR_MAP[themeMode];
@@ -551,6 +731,30 @@ function applyThemePaletteVariables(themeMode, palette) {
   rootStyle.setProperty(modeMap.accentText, palette.accentText || '#ffffff');
   rootStyle.setProperty(modeMap.shadow, palette.shadow);
   rootStyle.setProperty(modeMap.shadowCard, palette.shadowCard);
+}
+
+function applyColorSchemeById(schemeId, options = {}) {
+  const state = getBoardLabelState();
+  const scheme = getColorSchemeById(schemeId) || getDefaultColorScheme();
+  setBoardColorScheme(scheme.id);
+
+  // Clear legacy overrides when using a curated scheme
+  setBoardThemeOverrides({ light: {}, dark: {} });
+
+  const lightPalette = { ...scheme.light };
+  const darkPalette = { ...scheme.dark };
+  state.themePalettes = { light: lightPalette, dark: darkPalette };
+
+  applyThemePaletteVariables('light', lightPalette);
+  applyThemePaletteVariables('dark', darkPalette);
+
+  if (typeof setCustomOverTypeThemesFromBoardPalettes === 'function') {
+    setCustomOverTypeThemesFromBoardPalettes(state.themePalettes);
+  }
+
+  if (options.renderControls !== false) {
+    renderBoardThemeSettingsControls();
+  }
 }
 
 function applyDerivedBoardThemes(themeOverrides, options = {}) {
@@ -1082,76 +1286,25 @@ function renderThemeModePreview(themeMode, palette) {
 }
 
 function renderBoardThemeSettingsControls() {
-  const lightInput = document.getElementById('boardThemeLightBackground');
-  const darkInput = document.getElementById('boardThemeDarkBackground');
-  const warning = document.getElementById('boardThemeColorsWarning');
+  const select = document.getElementById('boardColorSchemeSelect');
   const palettes = getBoardThemePalettes();
-  const overrides = getBoardThemeOverrides();
+  const activeSchemeId = getBoardColorScheme() || 'light';
 
-  if (lightInput) {
-    lightInput.value = getEffectiveBoardThemeBackground('light');
-  }
-
-  if (darkInput) {
-    darkInput.value = getEffectiveBoardThemeBackground('dark');
+  if (select) {
+    const hadOptions = select.options.length > 0;
+    if (!hadOptions) {
+      for (const scheme of COLOR_SCHEMES) {
+        const option = document.createElement('option');
+        option.value = scheme.id;
+        option.textContent = scheme.name;
+        select.appendChild(option);
+      }
+    }
+    select.value = activeSchemeId;
   }
 
   renderThemeModePreview('light', palettes.light);
   renderThemeModePreview('dark', palettes.dark);
-
-  if (warning) {
-    const messages = [
-      createThemeWarningMessage('light', palettes.light),
-      createThemeWarningMessage('dark', palettes.dark),
-    ].filter(Boolean);
-
-    if (messages.length === 0) {
-      warning.classList.add('hidden');
-      warning.textContent = '';
-    } else {
-      warning.classList.remove('hidden');
-      warning.textContent = messages.join(' ');
-    }
-  }
-
-  const resetAllButton = document.getElementById('btnResetAllThemeColors');
-  if (resetAllButton) {
-    resetAllButton.disabled = !hasThemeModeOverride(overrides.light) && !hasThemeModeOverride(overrides.dark);
-  }
-}
-
-function updateBoardThemeOverride(themeMode, boardBackground) {
-  const normalizedBackground = normalizeHexColor(boardBackground, '');
-  const current = getBoardThemeOverrides();
-  const next = {
-    light: { ...current.light },
-    dark: { ...current.dark },
-  };
-
-  if (!normalizedBackground || normalizedBackground === DEFAULT_BOARD_THEME_BACKGROUNDS[themeMode]) {
-    delete next[themeMode].boardBackground;
-  } else {
-    next[themeMode].boardBackground = normalizedBackground;
-  }
-
-  applyDerivedBoardThemes(next);
-  scheduleBoardSettingsSave();
-}
-
-function resetBoardThemeMode(themeMode) {
-  const current = getBoardThemeOverrides();
-  const next = {
-    light: { ...current.light },
-    dark: { ...current.dark },
-  };
-  delete next[themeMode].boardBackground;
-  applyDerivedBoardThemes(next);
-  scheduleBoardSettingsSave();
-}
-
-function resetAllBoardThemeOverrides() {
-  applyDerivedBoardThemes({ light: {}, dark: {} });
-  scheduleBoardSettingsSave();
 }
 
 async function applyThemeOverridesToOpenBoards() {
@@ -1170,6 +1323,7 @@ async function applyThemeOverridesToOpenBoards() {
     }
 
     await window.board.updateBoardSettings(boardPath, {
+      colorScheme: getBoardColorScheme(),
       themeOverrides: sourceOverrides,
     });
   }
@@ -1379,12 +1533,18 @@ function persistBoardSettings() {
 
       const result = await window.board.updateBoardSettings(window.boardRoot, {
         labels: getBoardLabels(),
+        colorScheme: getBoardColorScheme(),
         themeOverrides: getBoardThemeOverrides(),
         notifications: getBoardNotificationSettings(),
         tooltipsEnabled: getBoardTooltipsEnabled(),
       });
       setBoardLabels(result.labels || []);
-      applyDerivedBoardThemes(result.themeOverrides || {}, { renderControls: false });
+      const savedSchemeId = result.colorScheme || '';
+      if (savedSchemeId && getColorSchemeById(savedSchemeId)) {
+        applyColorSchemeById(savedSchemeId, { renderControls: false });
+      } else {
+        applyDerivedBoardThemes(result.themeOverrides || {}, { renderControls: false });
+      }
       setBoardNotificationSettings(result.notifications || DEFAULT_BOARD_NOTIFICATION_SETTINGS);
       setBoardTooltipsEnabled(result.tooltipsEnabled);
       if (!isBoardSettingsModalOpen()) {
@@ -1776,7 +1936,7 @@ async function ensureBoardLabelsLoaded() {
     const state = getBoardLabelState();
     state.importSummaryBoardRoot = '';
     setBoardLabels([]);
-    applyDerivedBoardThemes({ light: {}, dark: {} }, { renderControls: false });
+    applyColorSchemeById('light', { renderControls: false });
     setBoardNotificationSettings(DEFAULT_BOARD_NOTIFICATION_SETTINGS);
     setBoardTooltipsEnabled(DEFAULT_BOARD_TOOLTIPS_ENABLED);
     renderBoardLabelFilterButton();
@@ -1790,7 +1950,12 @@ async function ensureBoardLabelsLoaded() {
 
   const settings = await window.board.readBoardSettings(window.boardRoot);
   setBoardLabels(settings.labels || []);
-  applyDerivedBoardThemes(settings.themeOverrides || {}, { renderControls: false });
+  const loadedSchemeId = settings.colorScheme || '';
+  if (loadedSchemeId && getColorSchemeById(loadedSchemeId)) {
+    applyColorSchemeById(loadedSchemeId, { renderControls: false });
+  } else {
+    applyDerivedBoardThemes(settings.themeOverrides || {}, { renderControls: false });
+  }
   setBoardNotificationSettings(settings.notifications || DEFAULT_BOARD_NOTIFICATION_SETTINGS);
   setBoardTooltipsEnabled(settings.tooltipsEnabled);
   renderBoardLabelFilterButton();
@@ -1822,11 +1987,7 @@ function initializeBoardLabelControls() {
   const renameBoardInput = document.getElementById('boardSettingsBoardNameInput');
   const renameBoardButton = document.getElementById('btnRenameBoard');
   const moveBoardButton = document.getElementById('btnMoveBoard');
-  const lightThemeBackgroundInput = document.getElementById('boardThemeLightBackground');
-  const darkThemeBackgroundInput = document.getElementById('boardThemeDarkBackground');
-  const resetLightThemeButton = document.getElementById('btnResetLightTheme');
-  const resetDarkThemeButton = document.getElementById('btnResetDarkTheme');
-  const resetAllThemeButton = document.getElementById('btnResetAllThemeColors');
+  const colorSchemeSelect = document.getElementById('boardColorSchemeSelect');
   const applyThemeToOpenBoardsButton = document.getElementById('btnApplyThemeColorsToOpenBoards');
   const notificationsToggle = document.getElementById('boardSettingsNotificationsToggle');
   const notificationsTimeInput = document.getElementById('boardSettingsNotificationsTime');
@@ -1983,39 +2144,11 @@ function initializeBoardLabelControls() {
     });
   }
 
-  if (lightThemeBackgroundInput) {
-    lightThemeBackgroundInput.addEventListener('input', (event) => {
-      updateBoardThemeOverride('light', event.target.value);
-    });
-  }
-
-  if (darkThemeBackgroundInput) {
-    darkThemeBackgroundInput.addEventListener('input', (event) => {
-      updateBoardThemeOverride('dark', event.target.value);
-    });
-  }
-
-  if (resetLightThemeButton) {
-    resetLightThemeButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      resetBoardThemeMode('light');
-    });
-  }
-
-  if (resetDarkThemeButton) {
-    resetDarkThemeButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      resetBoardThemeMode('dark');
-    });
-  }
-
-  if (resetAllThemeButton) {
-    resetAllThemeButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      resetAllBoardThemeOverrides();
+  if (colorSchemeSelect) {
+    colorSchemeSelect.addEventListener('change', (event) => {
+      const schemeId = event.target.value;
+      applyColorSchemeById(schemeId);
+      scheduleBoardSettingsSave();
     });
   }
 

--- a/app/board/boardLabels.js
+++ b/app/board/boardLabels.js
@@ -608,20 +608,15 @@ function getBoardLabelColor(label) {
 function createReadableLabelColors(baseColor, fallbackColor = '#3b82f6') {
   const normalizedBaseColor = normalizeHexColor(baseColor, normalizeHexColor(fallbackColor, '#3b82f6'));
   const palettes = getBoardThemePalettes();
-  const lightSurface = normalizeHexColor(
-    palettes && palettes.light ? palettes.light.surface : '',
-    DEFAULT_BOARD_THEME_PALETTES.light.surface,
-  );
   const darkSurface = normalizeHexColor(
     palettes && palettes.dark ? palettes.dark.surface : '',
     DEFAULT_BOARD_THEME_PALETTES.dark.surface,
   );
 
-  const lightAdjusted = ensureMinContrast(normalizedBaseColor, lightSurface, 4.5).color;
-  const darkAdjusted = ensureMinContrast(lightAdjusted, darkSurface, 4.5).color;
+  const darkAdjusted = ensureMinContrast(normalizedBaseColor, darkSurface, 4.5).color;
 
   return {
-    colorLight: lightAdjusted,
+    colorLight: normalizedBaseColor,
     colorDark: darkAdjusted,
   };
 }
@@ -1004,9 +999,11 @@ function createBoardSettingsLabelRow(label, index) {
   lightInput.value = label.colorLight;
   lightInput.className = 'board-settings-label-color';
   lightInput.title = 'Label color';
-  lightInput.addEventListener('input', (event) => {
+  const handleColorChange = (event) => {
     updateBoardLabel(index, 'colorLight', event.target.value);
-  });
+  };
+  lightInput.addEventListener('input', handleColorChange);
+  lightInput.addEventListener('change', handleColorChange);
 
   const deleteButton = document.createElement('button');
   deleteButton.type = 'button';

--- a/app/board/boardViews.js
+++ b/app/board/boardViews.js
@@ -643,6 +643,9 @@ function toggleBoardViewPopover() {
   if (typeof closeCardLabelPopover === 'function') {
     closeCardLabelPopover();
   }
+  if (typeof closeListActionsPopover === 'function') {
+    closeListActionsPopover();
+  }
 
   renderBoardViewPopover();
   const isHidden = popover.classList.contains('hidden');

--- a/app/board/openBoard.js
+++ b/app/board/openBoard.js
@@ -67,7 +67,6 @@ async function pickAndOpenBoard() {
         return false;
     }
 
-    await window.board.importFromTrello(authorizedBoardPath);
     return openBoard(authorizedBoardPath);
 }
 

--- a/app/board/renderBoard.js
+++ b/app/board/renderBoard.js
@@ -315,6 +315,11 @@ async function renderBoard() {
   renderState.requestId = requestId;
   const boardRoot = window.boardRoot; // set in the drop-zone handler
 
+  closeCardLabelPopover();
+  if (typeof closeListActionsPopover === 'function') {
+    closeListActionsPopover();
+  }
+
   if (!boardRoot) {
     setBoardChromeState(false);
     renderBoardTabs();
@@ -322,7 +327,6 @@ async function renderBoard() {
     return;
   }
 
-  closeCardLabelPopover();
   setBoardChromeState(true);
 
   const boardEl = document.getElementById('board');

--- a/app/init.js
+++ b/app/init.js
@@ -694,11 +694,17 @@ async function init() {
         if (typeof closeBoardViewPopoverIfClickOutside === 'function') {
             closeBoardViewPopoverIfClickOutside(e.target);
         }
+        if (typeof closeListActionsPopoverIfClickOutside === 'function') {
+            closeListActionsPopoverIfClickOutside(e.target);
+        }
 
         await closeAllModals(e);
     });
     document.getElementById('btnAddNewList').addEventListener('click', async (e) => {
         e.stopPropagation();
+        if (typeof closeListActionsPopover === 'function') {
+            closeListActionsPopover();
+        }
         const listName = document.getElementById('userInputListName');
         toggleAddListModal( (window.innerWidth / 2)-200, (window.innerHeight / 2)-100 );
         listName.focus();

--- a/app/listeners/window.js
+++ b/app/listeners/window.js
@@ -102,6 +102,20 @@ function isKeyboardShortcutsShortcut(event) {
     return event.code === 'Slash' || key === '/';
 }
 
+function focusBoardSearchInput() {
+    const searchInput = document.getElementById('boardSearchInput');
+    if (!searchInput) {
+        return false;
+    }
+
+    searchInput.focus();
+    if (typeof searchInput.select === 'function') {
+        searchInput.select();
+    }
+
+    return true;
+}
+
 syncShortcutHelpModifierLabels();
 
 if (window.electronAPI && typeof window.electronAPI.onOpenKeyboardShortcuts === 'function') {
@@ -132,6 +146,14 @@ window.addEventListener('keydown', async (e) => {
 
         if (handleBoardViewShortcut(e)) {
             hideShortcutHelpModal();
+            return;
+        }
+
+        if (String(e.key || '').toLowerCase() === 'f' && !e.shiftKey && !e.altKey) {
+            if (focusBoardSearchInput()) {
+                e.preventDefault();
+                hideShortcutHelpModal();
+            }
             return;
         }
         

--- a/app/lists/createListElement.js
+++ b/app/lists/createListElement.js
@@ -30,34 +30,23 @@ async function createListElement(name, listPath, cardNames, options = {}) {
 
   listName.addEventListener('focusout', async (e) => { await renameList(e) });
 
-  const addBtn = document.createElement('button');
-  addBtn.textContent = '+';
-  addBtn.title = 'Add new card';
-  addBtn.setAttribute('data-listpath', listPath + '/');
-  addBtn.setAttribute('class','btnOpenAddCardModal');
-  addBtn.addEventListener('click', async function (e) {
+  const actionsBtn = document.createElement('button');
+  actionsBtn.type = 'button';
+  actionsBtn.className = 'list-actions-button';
+  actionsBtn.title = 'List actions';
+  actionsBtn.setAttribute('aria-label', 'List actions');
+  actionsBtn.innerHTML = '<i data-feather="more-horizontal"></i>';
+  actionsBtn.addEventListener('click', async function (e) {
     e.stopPropagation();
-    
-    toggleAddCardModal( e.x-90, e.y+15 );
-    const userInput = document.getElementById('userInput');
-    userInput.focus();
-
-    const hiddenListPath = document.getElementById('hiddenListPath');
-    hiddenListPath.value = this.dataset.listpath;
-    
-    const btnAddCard = document.getElementById('btnAddCard');
-    btnAddCard.onclick = async function (e) {
-      e.stopPropagation();
-        const userInput = document.getElementById('userInput');
-        const hiddenListPath = document.getElementById('hiddenListPath');
-
-        await processAddNewCard( userInput.value, hiddenListPath.value );
-        userInput.value = '';
-        hiddenListPath.value = '';
-    };
+    toggleListActionsPopover({
+      anchorElement: actionsBtn,
+      listPath,
+      listDisplayName: listName.textContent,
+      cardCount: cardNames.length,
+    });
   });
   header.appendChild(listName);
-  header.appendChild(addBtn);
+  header.appendChild(actionsBtn);
   listEl.appendChild(header);
 
   const cardsEl = document.createElement('div');

--- a/app/lists/listActionsPopover.js
+++ b/app/lists/listActionsPopover.js
@@ -1,0 +1,286 @@
+function getListActionsPopoverState() {
+  if (!window.__listActionsPopoverState) {
+    window.__listActionsPopoverState = {
+      anchorElement: null,
+      listPath: '',
+      listDisplayName: '',
+      cardCount: 0,
+    };
+  }
+
+  return window.__listActionsPopoverState;
+}
+
+function normalizeListPathForCardCreation(listPath) {
+  const normalized = String(listPath || '').trim();
+  if (!normalized) {
+    return '';
+  }
+
+  return normalized.endsWith('/') ? normalized : `${normalized}/`;
+}
+
+function getAddCardModalCoordinates(anchorElement) {
+  const viewportPadding = 8;
+  const modalWidth = Math.min(360, Math.max(240, window.innerWidth - (viewportPadding * 2)));
+
+  if (!(anchorElement instanceof Element)) {
+    return {
+      left: Math.round(viewportPadding + window.scrollX),
+      top: Math.round(viewportPadding + window.scrollY),
+    };
+  }
+
+  const bounds = anchorElement.getBoundingClientRect();
+  const preferredLeft = bounds.left + (bounds.width / 2) - 90;
+  const clampedLeft = Math.min(
+    window.innerWidth - modalWidth - viewportPadding,
+    Math.max(viewportPadding, preferredLeft),
+  );
+
+  return {
+    left: Math.round(clampedLeft + window.scrollX),
+    top: Math.round(bounds.bottom + 15 + window.scrollY),
+  };
+}
+
+function configureAddCardModal(listPath) {
+  const hiddenListPath = document.getElementById('hiddenListPath');
+  const btnAddCard = document.getElementById('btnAddCard');
+
+  if (!hiddenListPath || !btnAddCard) {
+    return;
+  }
+
+  hiddenListPath.value = normalizeListPathForCardCreation(listPath);
+  btnAddCard.onclick = async (event) => {
+    event.stopPropagation();
+
+    const userInput = document.getElementById('userInput');
+    const activeListPath = document.getElementById('hiddenListPath');
+    if (!userInput || !activeListPath) {
+      return;
+    }
+
+    await processAddNewCard(userInput.value, activeListPath.value);
+    userInput.value = '';
+    activeListPath.value = '';
+  };
+}
+
+function openAddCardModalForList(listPath, anchorElement) {
+  const { left, top } = getAddCardModalCoordinates(anchorElement);
+
+  closeListActionsPopover();
+  configureAddCardModal(listPath);
+  toggleAddCardModal(left, top);
+
+  const userInput = document.getElementById('userInput');
+  if (userInput) {
+    userInput.focus();
+  }
+}
+
+function closeListActionsPopover() {
+  const popover = document.getElementById('listActionsPopover');
+  if (!popover) {
+    return;
+  }
+
+  popover.classList.add('hidden');
+  popover.setAttribute('aria-hidden', 'true');
+  popover.innerHTML = '';
+
+  const state = getListActionsPopoverState();
+  state.anchorElement = null;
+  state.listPath = '';
+  state.listDisplayName = '';
+  state.cardCount = 0;
+}
+
+function positionListActionsPopover(anchorElement, popover) {
+  if (!(anchorElement instanceof Element) || !(popover instanceof Element)) {
+    return;
+  }
+
+  const viewportPadding = 8;
+  const anchorBounds = anchorElement.getBoundingClientRect();
+
+  popover.style.position = 'fixed';
+  popover.style.left = '0px';
+  popover.style.top = '0px';
+
+  const popoverRect = popover.getBoundingClientRect();
+  const preferredLeft = anchorBounds.right - popoverRect.width;
+  const clampedLeft = Math.min(
+    window.innerWidth - popoverRect.width - viewportPadding,
+    Math.max(viewportPadding, preferredLeft),
+  );
+
+  let nextTop = anchorBounds.bottom + 8;
+  if (nextTop + popoverRect.height > window.innerHeight - viewportPadding) {
+    const aboveAnchor = anchorBounds.top - popoverRect.height - 8;
+    if (aboveAnchor >= viewportPadding) {
+      nextTop = aboveAnchor;
+    } else {
+      nextTop = Math.max(viewportPadding, window.innerHeight - popoverRect.height - viewportPadding);
+    }
+  }
+
+  popover.style.left = `${Math.round(clampedLeft)}px`;
+  popover.style.top = `${Math.round(nextTop)}px`;
+}
+
+function closeListActionsPopoverIfClickOutside(target) {
+  const popover = document.getElementById('listActionsPopover');
+  if (!popover || popover.classList.contains('hidden')) {
+    return;
+  }
+
+  const state = getListActionsPopoverState();
+  if (popover.contains(target) || (state.anchorElement && state.anchorElement.contains(target))) {
+    return;
+  }
+
+  closeListActionsPopover();
+}
+
+async function handleArchiveCardsInList(listPath, listDisplayName) {
+  const cardFiles = await window.board.listCards(listPath);
+  if (!Array.isArray(cardFiles) || cardFiles.length === 0) {
+    return;
+  }
+
+  const displayName = String(listDisplayName || '').trim() || 'this list';
+  const warningMessage = `Archive all cards in "${displayName}"?\n\nThis will move ${cardFiles.length} card${cardFiles.length === 1 ? '' : 's'} into XXX-Archive.`;
+  if (!window.confirm(warningMessage)) {
+    return;
+  }
+
+  closeListActionsPopover();
+
+  for (const cardFile of cardFiles) {
+    await window.board.archiveCard(`${normalizeListPathForCardCreation(listPath)}${cardFile}`);
+  }
+
+  await renderBoard();
+}
+
+async function handleArchiveList(listPath) {
+  closeListActionsPopover();
+  await window.board.archiveList(listPath);
+  await renderBoard();
+}
+
+function createListActionsOption(label, options = {}) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'list-actions-option';
+  button.textContent = label;
+  button.disabled = Boolean(options.disabled);
+
+  if (options.destructive) {
+    button.classList.add('list-actions-option-destructive');
+  }
+
+  if (typeof options.title === 'string' && options.title.trim()) {
+    button.title = options.title.trim();
+  }
+
+  if (typeof options.onClick === 'function') {
+    button.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (button.disabled) {
+        return;
+      }
+      await options.onClick();
+    });
+  }
+
+  return button;
+}
+
+function renderListActionsPopover() {
+  const popover = document.getElementById('listActionsPopover');
+  if (!popover) {
+    return null;
+  }
+
+  const state = getListActionsPopoverState();
+  popover.innerHTML = '';
+
+  const addCardButton = createListActionsOption('Add new card', {
+    onClick: async () => {
+      openAddCardModalForList(state.listPath, state.anchorElement);
+    },
+  });
+
+  const archiveCardsButton = createListActionsOption('Archive cards in this list', {
+    destructive: true,
+    disabled: state.cardCount === 0,
+    title: state.cardCount === 0 ? 'This list has no cards to archive' : '',
+    onClick: async () => {
+      await handleArchiveCardsInList(state.listPath, state.listDisplayName);
+    },
+  });
+
+  const archiveListButton = createListActionsOption('Archive this list', {
+    destructive: true,
+    onClick: async () => {
+      await handleArchiveList(state.listPath);
+    },
+  });
+
+  popover.appendChild(addCardButton);
+  popover.appendChild(archiveCardsButton);
+  popover.appendChild(archiveListButton);
+  popover.setAttribute('aria-hidden', 'false');
+  popover.onclick = (event) => {
+    event.stopPropagation();
+  };
+
+  return popover;
+}
+
+function toggleListActionsPopover({
+  anchorElement,
+  listPath,
+  listDisplayName,
+  cardCount,
+} = {}) {
+  const popover = document.getElementById('listActionsPopover');
+  if (!popover || !(anchorElement instanceof Element)) {
+    return;
+  }
+
+  const state = getListActionsPopoverState();
+  const isOpenForAnchor = (
+    !popover.classList.contains('hidden') &&
+    state.anchorElement === anchorElement
+  );
+
+  if (isOpenForAnchor) {
+    closeListActionsPopover();
+    return;
+  }
+
+  if (typeof closeBoardLabelFilterPopover === 'function') {
+    closeBoardLabelFilterPopover();
+  }
+  if (typeof closeCardLabelPopover === 'function') {
+    closeCardLabelPopover();
+  }
+  if (typeof closeBoardViewPopover === 'function') {
+    closeBoardViewPopover();
+  }
+
+  state.anchorElement = anchorElement;
+  state.listPath = String(listPath || '').trim();
+  state.listDisplayName = String(listDisplayName || '').trim();
+  state.cardCount = Math.max(0, Number(cardCount) || 0);
+
+  renderListActionsPopover();
+  popover.classList.remove('hidden');
+  positionListActionsPopover(anchorElement, popover);
+}

--- a/app/modals/closeAllModals.js
+++ b/app/modals/closeAllModals.js
@@ -99,6 +99,9 @@ async function closeAllModals(e, options = {}){
     if (closeAllRequest && typeof closeAllLabelPopovers === 'function') {
         closeAllLabelPopovers();
     }
+    if (closeAllRequest && typeof closeListActionsPopover === 'function') {
+        closeListActionsPopover();
+    }
 
     if ( closeAllRequest ) {
         if ( isVisibleModal(modalAddCard) ) {

--- a/app/modals/toggleEditCardModal.js
+++ b/app/modals/toggleEditCardModal.js
@@ -888,9 +888,9 @@ async function toggleEditCardModal(cardPath, options = {}) {
     cardEditorArchiveLink.onclick = async (e) => {
         const cardEditorCardPath = document.getElementById('cardEditorCardPath');
 
-        await window.board.moveCard( cardEditorCardPath.value, window.boardRoot + 'XXX-Archive/' + window.board.getCardFileName(cardEditorCardPath.value));
         e.preventDefault();
         e.stopPropagation();
+        await window.board.archiveCard(cardEditorCardPath.value);
         await closeAllModals(createCloseAllModalsRequest());
 
         return;

--- a/buildjs.sh
+++ b/buildjs.sh
@@ -14,6 +14,7 @@ cat \
   app/board/boardViews.js \
   app/cards/createCardElement.js \
   app/cards/processAddNewCard.js \
+  app/lists/listActionsPopover.js \
   app/lists/createListElement.js \
   app/cards/processAddNewList.js \
   app/listeners/window.js \

--- a/docs/codex/FILE_STRUCTURE.md
+++ b/docs/codex/FILE_STRUCTURE.md
@@ -51,7 +51,8 @@ This map focuses on source and operational files. Large generated/vendor folders
 - `lib/importers/shared.js` - Shared importer helpers for list/card creation, label reuse/creation, metadata section building, and markdown source discovery.
 - `lib/importers/trello.js` - Trello JSON importer.
 - `lib/importers/obsidian.js` - Obsidian importer covering `obsidian-kanban`, generic task scopes, and CardBoard snapshot imports.
-- `lib/mcpServer.js` - Headless MCP stdio server for agent access to board/list/card/settings operations, safe board creation, and task-summary metadata on card tools.
+- `lib/mcpServer.js` - Headless MCP stdio server for agent access to board/list/card/settings operations, safe board creation, Trello/Obsidian imports, and task-summary metadata on card tools.
+- `lib/cliApp.js` - CLI command parsing/output for `use`, `lists`, `cards`, `settings`, and path-based `import` commands.
 
 ## Scripts (`scripts/`)
 
@@ -65,7 +66,9 @@ This map focuses on source and operational files. Large generated/vendor folders
 - `scripts/migrate-legacy-cards.js` - Bulk migration to YAML frontmatter format.
 - `scripts/notarize.js` - electron-builder `afterSign` notarization hook.
 - `scripts/verify-release-assets.js` - Release checklist validator for updater metadata/assets across macOS/Windows/Linux.
-- `scripts/test-mcp-server.js` - MCP protocol smoke test across header + ndjson stdio transports, including card task metadata assertions.
+- `scripts/test-mcp-server.js` - MCP protocol smoke test across header + ndjson stdio transports, including card task metadata assertions and import-tool coverage.
+- `scripts/test-cli.js` - Node CLI smoke test covering list/card flows plus Trello/Obsidian imports.
+- `scripts/test-desktop-cli.js` - Electron executable CLI dispatch smoke test, including import command routing.
 
 ## Static assets (`static/`)
 

--- a/docs/codex/FILE_STRUCTURE.md
+++ b/docs/codex/FILE_STRUCTURE.md
@@ -24,7 +24,7 @@ This map focuses on source and operational files. Large generated/vendor folders
 - `app/utilities/santizeFileName.js` - Filename sanitization + random suffix helper.
 - `app/utilities/taskList.js` - Task checklist parser, due-marker helpers, task-summary counters, and task progress badge creation.
 - `app/utilities/dueNotifications.js` - Due-notification collection + message formatting for card due dates and task due markers.
-- `app/board/boardLabels.js` - Board-label state, toolbar filter UI, card label popovers, and board settings label editor.
+- `app/board/boardLabels.js` - Board-label state, toolbar filter UI, card label popovers, board settings editor, and Trello/Obsidian import panel wiring + summary rendering.
 - `app/board/boardSearch.js` - Board search state and input handling for filtering cards by title/body.
 - `app/board/boardViews.js` - Board view state, `Views` menu wiring, Calendar + This Week rendering/navigation/drag-to-reschedule logic, temporal card placement by card due/task due markers, and source-list labels on temporal cards.
 - `app/cards/createCardElement.js` - Card DOM rendering, task progress badge display, and click behavior.
@@ -47,6 +47,10 @@ This map focuses on source and operational files. Large generated/vendor folders
 
 - `lib/cardFrontmatter.js` - Card parse/normalize/read/write/update with legacy support.
 - `lib/boardLabels.js` - Board-level label settings read/write/defaults/filter helpers (`board-settings.md`).
+- `lib/importers/index.js` - Export surface for board importers.
+- `lib/importers/shared.js` - Shared importer helpers for list/card creation, label reuse/creation, metadata section building, and markdown source discovery.
+- `lib/importers/trello.js` - Trello JSON importer.
+- `lib/importers/obsidian.js` - Obsidian importer covering `obsidian-kanban`, generic task scopes, and CardBoard snapshot imports.
 - `lib/mcpServer.js` - Headless MCP stdio server for agent access to board/list/card/settings operations, safe board creation, and task-summary metadata on card tools.
 
 ## Scripts (`scripts/`)
@@ -55,6 +59,8 @@ This map focuses on source and operational files. Large generated/vendor folders
 - `scripts/test-board-labels.js` - Node assertions for board label settings defaults/migration/filter logic.
 - `scripts/test-board-card-metadata.js` - Board card metadata rendering assertions (due/labels/task badge behavior).
 - `scripts/test-due-notifications.js` - Due-notification assertions for task due item collection and notification body formatting.
+- `scripts/test-import-trello.js` - Trello importer assertions for order, label reuse, archive routing, and metadata preservation.
+- `scripts/test-import-obsidian.js` - Obsidian importer assertions for kanban/task/CardBoard cases, due conversion, and source-prefix naming.
 - `scripts/test-task-list-parser.js` - Task checklist parser assertions (`completed/total` and task due-date extraction).
 - `scripts/migrate-legacy-cards.js` - Bulk migration to YAML frontmatter format.
 - `scripts/notarize.js` - electron-builder `afterSign` notarization hook.

--- a/docs/codex/PROJECT_CONTEXT.md
+++ b/docs/codex/PROJECT_CONTEXT.md
@@ -19,6 +19,7 @@ File: `main.js`
 - Supports a headless MCP server mode when launched with `--mcp-server` (no window created).
 - Supports `--mcp-config` mode to print MCP client config JSON and exit.
 - Registers IPC handler `choose-directory` to open native folder picker.
+- Registers IPC handler `pick-import-sources` to open native file/directory pickers for Trello JSON and Obsidian markdown/vault sources.
 - Registers IPC handler `check-for-updates` for renderer-triggered manual update checks.
 - Builds a native app menu with a `Check for Updates...` action.
 - Help menu includes `Copy MCP Config` to copy a ready-to-paste Signboard MCP JSON snippet.
@@ -29,6 +30,7 @@ File: `main.js`
 - Persists remind-later per version in `update-preferences.json` under Electron `userData`.
 - Uses `preload.js` as a thin renderer bridge into main-process IPC.
 - Owns trusted board-root persistence, board path validation, and external board filesystem watchers.
+- Owns explicit board import operations for Trello and Obsidian; renderer code passes tokenized selections and the main process performs all external file reads and board writes.
 - In MCP mode, starts `lib/mcpServer.js` and communicates over stdio using MCP JSON-RPC framing.
 - MCP stdio transport supports both `Content-Length` framing and newline-delimited JSON-RPC for client compatibility.
 - Source checkouts also expose a Node CLI at `bin/signboard.js` for direct terminal list/card management.
@@ -46,6 +48,7 @@ File: `preload.js`
 - `window.electronAPI` includes external-link opening and manual update checks.
 - Proxies board operations to `main.js` over `ipcRenderer.invoke(...)`.
 - Does not use Node filesystem APIs directly.
+- `window.chooser.pickImportSources(...)` returns tokenized external file/directory selections for import flows, and `window.board.importTrello(...)` / `window.board.importObsidian(...)` invoke the main-process importers.
 - Still exposes board watch helpers (`startBoardWatch`, `stopBoardWatch`, `getBoardWatchToken`), but the watcher implementation now lives in `main.js`.
 
 ### Renderer
@@ -54,6 +57,7 @@ Files: `index.html`, `app/signboard.js` (generated), source modules in `app/**`
 - UI is vanilla HTML/CSS/JS.
 - `index.html` loads vendored libraries and `app/signboard.js` with `defer`.
 - `app/signboard.js` is concatenated from source modules by `buildjs.sh`.
+- Board Settings includes an `Import` section for Trello and Obsidian imports, with summary/warning rendering in the existing settings modal.
 
 ## Data Model and Naming Conventions
 
@@ -62,6 +66,7 @@ Files: `index.html`, `app/signboard.js` (generated), source modules in `app/**`
 - Open board tabs are persisted in `localStorage.boardTabs` (`[{ root, name }]`).
 - Active board root is mirrored in `localStorage.boardPath` for backward compatibility.
 - `board-settings.md` is auto-created with default label definitions when missing.
+- Imports are additive only: they create new lists/cards in the current board and never modify external source files.
 
 ### List directories
 - Pattern: `NNN-<list-name>-<suffix>`
@@ -104,6 +109,7 @@ Files: `index.html`, `app/signboard.js` (generated), source modules in `app/**`
   - Manages board tabs (add/open/close/reorder + active tab persistence).
   - Sets `window.boardRoot` and renders only the active board.
   - Uses `Open Board` for the folder picker label.
+  - No longer performs any implicit Trello import during board open; imports are settings-driven only.
 
 ### Rendering board/lists/cards
 - `app/board/renderBoard.js`:
@@ -133,7 +139,7 @@ Files: `index.html`, `app/signboard.js` (generated), source modules in `app/**`
 - `app/board/boardLabels.js`:
   - Owns board label state in the renderer.
   - Renders board label filter dropdown (multi-select, OR matching).
-  - Handles card label popovers and board settings label editor.
+  - Handles card label popovers, board settings editors, and the Board Settings import UI/actions.
   - Persists board labels through preload APIs.
 - `app/board/boardSearch.js`:
   - Stores the current search query/tokens.
@@ -207,6 +213,16 @@ File: `lib/boardLabels.js`
 - Migrates legacy `labels.md` reads into `board-settings.md`.
 - Exposes OR-based label filtering helper logic.
 
+## Importers
+Files: `lib/importers/*`
+
+- `lib/importers/trello.js` imports Trello board JSON into Signboard lists/cards, preserving labels, checklists, comments, attachments, due dates, and archive routing for closed Trello content.
+- `lib/importers/obsidian.js` imports:
+  - markdown-backed `obsidian-kanban` boards
+  - generic task-based Obsidian markdown scopes
+  - CardBoard vault snapshots when `.obsidian/plugins/card-board/data.json` is available
+- `lib/importers/shared.js` owns list/card creation helpers, label reconciliation, import summaries, markdown metadata sections, and recursive markdown file discovery.
+
 ## Tooling, Build, and Test
 
 ### Run locally
@@ -242,6 +258,11 @@ File: `lib/boardLabels.js`
 ### Board label tests
 - `npm run test:board-labels`
 - Script: `scripts/test-board-labels.js`
+
+### Importer tests
+- `npm run test:import-trello`
+- `npm run test:import-obsidian`
+- Scripts: `scripts/test-import-trello.js`, `scripts/test-import-obsidian.js`
 
 ### MCP smoke test
 - `npm run test:mcp`

--- a/docs/codex/PROJECT_CONTEXT.md
+++ b/docs/codex/PROJECT_CONTEXT.md
@@ -232,7 +232,10 @@ Files: `lib/importers/*`
 - `npm run cli -- <command>`
 - `node bin/signboard.js <command>`
 - `electron . <command>` routes through the desktop executable path used by packaged builds.
-- CLI board selection is stateful: `signboard use /path/to/board`, then `signboard lists`, `signboard cards`, or `signboard cards "List Name"`.
+- CLI board selection is stateful: `signboard use /path/to/board`, then `signboard lists`, `signboard cards`, `signboard settings`, or `signboard import ...`.
+- Import commands:
+  - `signboard import trello --file /absolute/or/relative/export.json [--board <path>] [--json]`
+  - `signboard import obsidian --source /path/to/file-or-dir [--source /another/path] [--board <path>] [--json]`
 
 ### Run MCP server locally
 - `npm run mcp:server`
@@ -247,7 +250,7 @@ Files: `lib/importers/*`
 ### CLI internals
 - `lib/cliBoard.js` owns CLI board/list/card filesystem operations.
 - `lib/taskList.js` exposes shared task parsing and due-date helpers for CLI filtering.
-- `lib/cliApp.js` owns shared command parsing/output used by both the Node shim and Electron executable.
+- `lib/cliApp.js` owns shared command parsing/output used by both the Node shim and Electron executable, including path-based Trello/Obsidian imports.
 - `lib/cliInstall.js` owns user-level CLI shim + shell profile installation.
 - `lib/cliState.js` persists the currently selected board for subsequent CLI commands.
 
@@ -267,17 +270,17 @@ Files: `lib/importers/*`
 ### MCP smoke test
 - `npm run test:mcp`
 - Script: `scripts/test-mcp-server.js`
-- Asserts card tool outputs include `taskSummary` + `taskDueDates`.
+- Asserts card tool outputs include `taskSummary` + `taskDueDates`, and verifies Trello/Obsidian import tools.
 
 ### CLI smoke test
 - `npm run test:cli`
 - Script: `scripts/test-cli.js`
-- Covers list creation/rename plus card create/edit/read/filter flows.
+- Covers list creation/rename, card create/edit/read/filter flows, and Trello/Obsidian imports.
 
 ### Desktop CLI smoke test
 - `npm run test:desktop-cli`
 - Script: `scripts/test-desktop-cli.js`
-- Verifies Electron executable CLI dispatch without opening the UI.
+- Verifies Electron executable CLI dispatch without opening the UI, including import command routing.
 
 ### CLI installer test
 - `npm run test:cli-install`

--- a/index.html
+++ b/index.html
@@ -62,6 +62,8 @@
     </button>
   </main>
 
+  <div id="listActionsPopover" class="label-popover list-actions-popover hidden" aria-hidden="true"></div>
+
   <div id="modalAddList" class="modal hidden">
     <input id="userInputListName" type="text" placeholder="Backlog">
     <button id="btnAddList" title="Add list">Add List</button>

--- a/index.html
+++ b/index.html
@@ -117,6 +117,15 @@
           </li>
         </ul>
       </section>
+      <section class="keyboard-shortcuts-section" aria-labelledby="keyboard-shortcuts-section-search">
+        <h3 id="keyboard-shortcuts-section-search">Search</h3>
+        <ul class="keyboard-shortcuts-list">
+          <li>
+            <span>Focus search</span>
+            <kbd><span class="shortcut-key-modifier">⌘</span> + F</kbd>
+          </li>
+        </ul>
+      </section>
       <section class="keyboard-shortcuts-section" aria-labelledby="keyboard-shortcuts-section-modals">
         <h3 id="keyboard-shortcuts-section-modals">Modals</h3>
         <ul class="keyboard-shortcuts-list">

--- a/index.html
+++ b/index.html
@@ -185,32 +185,33 @@
   <div id="modalCommercialLicense" class="modal commercial-license-modal hidden" role="dialog" aria-modal="true" aria-labelledby="commercialLicenseTitle" aria-hidden="true">
     <div class="commercial-license-header">
       <div>
-        <p class="commercial-license-eyebrow">Free for personal use</p>
+        <!-- <p class="commercial-license-eyebrow">Free for personal use</p> -->
         <h2 id="commercialLicenseTitle">Support Signboard when it supports your work</h2>
       </div>
       <button id="commercialLicenseClose" class="commercial-license-close" type="button" title="Close commercial use modal" aria-label="Close commercial use modal"><i data-feather="x"></i></button>
     </div>
     <div class="commercial-license-copy">
-      <p>Hi, I’m Colin. I want Signboard to stay open source and free for personal use.</p>
+      <p>Hi, I’m Colin. 👋</p>
+      <p>I want Signboard to stay open source and free for personal use.</p>
       <p>If you start using Signboard to manage work that earns you money, I’d really appreciate your support with a one-time commercial-use payment.</p>
     </div>
     <div class="commercial-license-card">
       <div class="commercial-license-card-copy">
         <p class="commercial-license-card-label">Commercial-use support</p>
         <p class="commercial-license-card-price"><span data-commercial-license-price>$49</span> one-time</p>
-        <p class="commercial-license-card-note">No subscription. Pay once and keep using Signboard for commercial work.</p>
+        <p class="commercial-license-card-note">No subscription. Pay once and keep using the <applet></applet> for commercial work.</p>
       </div>
       <button id="commercialLicensePayButton" class="commercial-license-pay-button" type="button">Pay $49</button>
     </div>
     <div class="commercial-license-tip">
       <div class="commercial-license-tip-copy">
-        <p class="commercial-license-tip-title">Using Signboard personally?</p>
-        <p class="commercial-license-tip-note">If it helps with your own projects and you want to support development, you can leave a tip in any amount.</p>
+        <p class="commercial-license-tip-title">Tips are appreciated</p>
+        <p class="commercial-license-tip-note">If you want to support development or just want to say thanks, you can leave a tip of any amount.</p>
       </div>
       <button id="commercialLicenseTipButton" class="commercial-license-tip-button" type="button">Leave a Tip</button>
     </div>
-    <p id="commercialLicensePaymentHelper" class="commercial-license-helper">Personal use stays free.</p>
-    <p class="commercial-license-signoff">Thanks for your support.<br>Colin</p>
+    <!-- <p id="commercialLicensePaymentHelper" class="commercial-license-helper">Personal use stays free.</p> -->
+    <!-- <p class="commercial-license-signoff">Thanks for your support.<br>Colin</p> -->
   </div>
 
   <div id="modalBoardSettings" class="modal hidden">
@@ -265,26 +266,23 @@
         </section>
 
         <section id="boardSettingsPanelColors" class="boardSettingsSection board-settings-panel" data-settings-panel="colors">
-          <h3>Colors</h3>
-          <p class="boardSettingsHint">Choose the board background color and the rest of the palette is chosen automatically for readability.</p>
+          <h3>Color Scheme</h3>
+          <p class="boardSettingsHint">Choose a color scheme for this board. Each scheme has a light and dark variant.</p>
+          <div class="board-color-scheme-selector">
+            <select id="boardColorSchemeSelect" aria-label="Color scheme"></select>
+          </div>
           <div class="board-theme-settings-grid">
             <div class="board-theme-settings-mode">
-              <h4>Light theme</h4>
-              <input id="boardThemeLightBackground" type="color" value="#f7f8fa">
-              <p class="board-theme-picker-hint">Click swatch to pick a color.</p>
-              <button id="btnResetLightTheme" type="button" title="Reset light theme colors">Reset Light Theme</button>
+              <h4>Light</h4>
+              <div id="boardThemeLightPreview" class="board-theme-preview"></div>
             </div>
             <div class="board-theme-settings-mode">
-              <h4>Dark theme</h4>
-              <input id="boardThemeDarkBackground" type="color" value="#091102">
-              <p class="board-theme-picker-hint">Click swatch to pick a color.</p>
-              <button id="btnResetDarkTheme" type="button" title="Reset dark theme colors">Reset Dark Theme</button>
+              <h4>Dark</h4>
+              <div id="boardThemeDarkPreview" class="board-theme-preview"></div>
             </div>
           </div>
-          <p id="boardThemeColorsWarning" class="boardSettingsHint board-theme-warning hidden"></p>
           <div class="board-theme-settings-actions">
-            <button id="btnResetAllThemeColors" type="button" title="Reset all theme colors">Reset All Theme Colors</button>
-            <button id="btnApplyThemeColorsToOpenBoards" type="button" title="Apply theme colors to all open boards">Apply to all Open Boards</button>
+            <button id="btnApplyThemeColorsToOpenBoards" type="button" title="Apply color scheme to all open boards">Apply to all Open Boards</button>
           </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -213,6 +213,7 @@
         <button id="boardSettingsNavLabels" type="button" class="board-settings-nav-button" data-settings-panel="labels">Labels</button>
         <button id="boardSettingsNavColors" type="button" class="board-settings-nav-button" data-settings-panel="colors">Colors</button>
         <button id="boardSettingsNavNotifications" type="button" class="board-settings-nav-button" data-settings-panel="notifications">Notifications</button>
+        <button id="boardSettingsNavImport" type="button" class="board-settings-nav-button" data-settings-panel="import">Import</button>
       </nav>
       <div class="board-settings-panels">
         <section id="boardSettingsPanelGeneral" class="boardSettingsSection board-settings-panel is-active" data-settings-panel="general">
@@ -296,6 +297,30 @@
           <div class="board-theme-settings-actions">
             <button id="btnApplyNotificationsToOpenBoards" type="button" title="Apply notification settings to all open boards">Apply to all Open Boards</button>
           </div>
+        </section>
+
+        <section id="boardSettingsPanelImport" class="boardSettingsSection board-settings-panel" data-settings-panel="import">
+          <h3>Import</h3>
+          <p class="boardSettingsHint"><strong>Note: This feature is in rapid improvement.</strong> Import data from other apps into this board. Signboard copies data in and leaves your source files where they are.</p>
+
+          <div class="board-import-option">
+            <h4>Trello</h4>
+            <p class="boardSettingsHint">Export from Trello by opening the board menu, choosing Print > Export > Share, and then exporting the board as a JSON file.</p>
+            <div class="board-settings-inline-actions board-settings-inline-actions-right">
+              <button id="btnImportBoardFromTrello" type="button" title="Import from Trello">Import from Trello</button>
+            </div>
+          </div>
+
+          <div class="board-import-option">
+            <h4>Obsidian</h4>
+            <p class="boardSettingsHint">Choose one markdown file, several markdown files, or an entire Obsidian folder. Signboard will try to preserve lists, cards, order, dates, labels, and extra metadata.</p>
+            <div class="board-settings-inline-actions board-settings-inline-actions-right">
+              <button id="btnImportBoardFromObsidian" type="button" title="Import from Obsidian">Import from Obsidian</button>
+            </div>
+          </div>
+
+          <div id="boardSettingsImportStatus" class="board-import-status hidden" aria-live="polite"></div>
+          <div id="boardSettingsImportWarnings" class="board-import-warnings hidden"></div>
         </section>
       </div>
     </div>

--- a/lib/archive.js
+++ b/lib/archive.js
@@ -1,0 +1,237 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const ARCHIVE_DIRECTORY_NAME = 'XXX-Archive';
+const CARD_PREFIX_PATTERN = /^(\d{3})(.*)$/;
+
+function normalizeAbsolutePath(rawPath) {
+  const value = typeof rawPath === 'string' ? rawPath.trim() : '';
+  if (!value) {
+    throw new Error('Path is required.');
+  }
+
+  return path.resolve(value);
+}
+
+async function ensureDirectory(directoryPath, label) {
+  let stats;
+
+  try {
+    stats = await fs.stat(directoryPath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(`${label} does not exist: ${directoryPath}`);
+    }
+    throw error;
+  }
+
+  if (!stats.isDirectory()) {
+    throw new Error(`${label} is not a directory: ${directoryPath}`);
+  }
+}
+
+async function ensureFile(filePath, label) {
+  let stats;
+
+  try {
+    stats = await fs.stat(filePath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(`${label} does not exist: ${filePath}`);
+    }
+    throw error;
+  }
+
+  if (!stats.isFile()) {
+    throw new Error(`${label} is not a file: ${filePath}`);
+  }
+}
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isPathInside(rootPath, targetPath) {
+  const relative = path.relative(rootPath, targetPath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function randomSuffix(length = 5) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let output = '';
+
+  for (let index = 0; index < length; index += 1) {
+    output += alphabet.charAt(Math.floor(Math.random() * alphabet.length));
+  }
+
+  return output;
+}
+
+async function nextArchiveCardPrefix(archiveRoot) {
+  const entries = await fs.readdir(archiveRoot, { withFileTypes: true });
+  let maxPrefix = 0;
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) {
+      continue;
+    }
+
+    const match = entry.name.match(/^(\d{3})-/);
+    if (!match) {
+      continue;
+    }
+
+    const prefix = Number(match[1]);
+    if (Number.isFinite(prefix) && prefix > maxPrefix) {
+      maxPrefix = prefix;
+    }
+  }
+
+  return String(maxPrefix + 1).padStart(3, '0');
+}
+
+function getArchiveRoot(boardRoot) {
+  return path.join(boardRoot, ARCHIVE_DIRECTORY_NAME);
+}
+
+async function ensureArchiveRoot(boardRoot) {
+  const archiveRoot = getArchiveRoot(boardRoot);
+
+  if (!(await pathExists(archiveRoot))) {
+    await fs.mkdir(archiveRoot, { recursive: true });
+    return archiveRoot;
+  }
+
+  await ensureDirectory(archiveRoot, 'Archive directory');
+  return archiveRoot;
+}
+
+function isAlreadyArchived(boardRoot, sourcePath) {
+  const archiveRoot = getArchiveRoot(boardRoot);
+  return isPathInside(archiveRoot, sourcePath);
+}
+
+function buildArchivedCardFileName(cardFile, nextPrefix) {
+  const match = String(cardFile || '').match(CARD_PREFIX_PATTERN);
+  if (!match) {
+    return `${nextPrefix}-${cardFile}`;
+  }
+
+  return `${nextPrefix}${match[2]}`;
+}
+
+async function archiveCard(boardRoot, cardPath) {
+  const normalizedBoardRoot = normalizeAbsolutePath(boardRoot);
+  const normalizedCardPath = normalizeAbsolutePath(cardPath);
+
+  await ensureDirectory(normalizedBoardRoot, 'Board root');
+
+  if (!isPathInside(normalizedBoardRoot, normalizedCardPath)) {
+    throw new Error('Card path resolved outside board root.');
+  }
+
+  if (normalizedCardPath === normalizedBoardRoot) {
+    throw new Error('Board root cannot be archived as a card.');
+  }
+
+  if (isAlreadyArchived(normalizedBoardRoot, normalizedCardPath)) {
+    return {
+      ok: true,
+      boardRoot: normalizedBoardRoot,
+      archiveRoot: getArchiveRoot(normalizedBoardRoot),
+      cardFile: path.basename(normalizedCardPath),
+      archivedCardFile: path.basename(normalizedCardPath),
+      archivedCardPath: normalizedCardPath,
+      alreadyArchived: true,
+    };
+  }
+
+  await ensureFile(normalizedCardPath, 'Card');
+
+  const archiveRoot = await ensureArchiveRoot(normalizedBoardRoot);
+  let archivedCardFile = path.basename(normalizedCardPath);
+  let archivedCardPath = path.join(archiveRoot, archivedCardFile);
+
+  while (await pathExists(archivedCardPath)) {
+    const nextPrefix = await nextArchiveCardPrefix(archiveRoot);
+    archivedCardFile = buildArchivedCardFileName(archivedCardFile, nextPrefix);
+    archivedCardPath = path.join(archiveRoot, archivedCardFile);
+  }
+
+  await fs.rename(normalizedCardPath, archivedCardPath);
+
+  return {
+    ok: true,
+    boardRoot: normalizedBoardRoot,
+    archiveRoot,
+    cardFile: path.basename(normalizedCardPath),
+    archivedCardFile,
+    archivedCardPath,
+    alreadyArchived: false,
+  };
+}
+
+async function archiveList(boardRoot, listPath) {
+  const normalizedBoardRoot = normalizeAbsolutePath(boardRoot);
+  const normalizedListPath = normalizeAbsolutePath(listPath);
+
+  await ensureDirectory(normalizedBoardRoot, 'Board root');
+
+  if (!isPathInside(normalizedBoardRoot, normalizedListPath)) {
+    throw new Error('List path resolved outside board root.');
+  }
+
+  if (normalizedListPath === normalizedBoardRoot) {
+    throw new Error('Board root cannot be archived as a list.');
+  }
+
+  if (isAlreadyArchived(normalizedBoardRoot, normalizedListPath)) {
+    return {
+      ok: true,
+      boardRoot: normalizedBoardRoot,
+      archiveRoot: getArchiveRoot(normalizedBoardRoot),
+      listDirectoryName: path.basename(normalizedListPath),
+      archivedDirectoryName: path.basename(normalizedListPath),
+      archivedListPath: normalizedListPath,
+      alreadyArchived: true,
+    };
+  }
+
+  await ensureDirectory(normalizedListPath, 'List');
+
+  const archiveRoot = await ensureArchiveRoot(normalizedBoardRoot);
+  const originalDirectoryName = path.basename(normalizedListPath);
+  let archivedDirectoryName = originalDirectoryName;
+  let archivedListPath = path.join(archiveRoot, archivedDirectoryName);
+
+  while (await pathExists(archivedListPath)) {
+    archivedDirectoryName = `${originalDirectoryName}-${randomSuffix()}`;
+    archivedListPath = path.join(archiveRoot, archivedDirectoryName);
+  }
+
+  await fs.rename(normalizedListPath, archivedListPath);
+
+  return {
+    ok: true,
+    boardRoot: normalizedBoardRoot,
+    archiveRoot,
+    listDirectoryName: originalDirectoryName,
+    archivedDirectoryName,
+    archivedListPath,
+    alreadyArchived: false,
+  };
+}
+
+module.exports = {
+  ARCHIVE_DIRECTORY_NAME,
+  archiveCard,
+  archiveList,
+};

--- a/lib/boardLabels.js
+++ b/lib/boardLabels.js
@@ -204,6 +204,7 @@ function normalizeBoardSettings(rawSettings = {}) {
   const source = isObject(rawSettings) ? rawSettings : {};
   return {
     labels: normalizeLabels(source.labels),
+    colorScheme: typeof source.colorScheme === 'string' ? source.colorScheme : '',
     themeOverrides: normalizeThemeOverrides(source.themeOverrides),
     notifications: normalizeNotificationSettings(source.notifications),
     tooltipsEnabled: normalizeTooltipsEnabled(source.tooltipsEnabled),
@@ -217,6 +218,10 @@ function serializeBoardSettings(settings) {
     notifications: normalized.notifications,
     tooltipsEnabled: normalized.tooltipsEnabled,
   };
+
+  if (normalized.colorScheme) {
+    serializable.colorScheme = normalized.colorScheme;
+  }
 
   if (themeOverridesHasValues(normalized.themeOverrides)) {
     serializable.themeOverrides = {};
@@ -393,6 +398,12 @@ async function updateBoardSettings(boardRoot, partialSettings = {}) {
 
   if ('labels' in partialSettings) {
     nextSettings.labels = partialSettings.labels;
+  }
+
+  if ('colorScheme' in partialSettings) {
+    nextSettings.colorScheme = typeof partialSettings.colorScheme === 'string'
+      ? partialSettings.colorScheme
+      : '';
   }
 
   if ('themeOverrides' in partialSettings) {

--- a/lib/cliApp.js
+++ b/lib/cliApp.js
@@ -2,6 +2,10 @@ const fs = require('fs').promises;
 const path = require('path');
 const boardLabels = require('./boardLabels');
 const {
+  importTrello,
+  importObsidian,
+} = require('./importers');
+const {
   listLists,
   createList,
   renameList,
@@ -17,9 +21,10 @@ const {
   setCurrentBoard,
 } = require('./cliState');
 
-const CLI_GROUPS = new Set(['use', 'lists', 'cards', 'settings']);
+const CLI_GROUPS = new Set(['use', 'lists', 'cards', 'settings', 'import']);
 const CLI_NEAR_MISSES = new Set(['list', 'card']);
 const CARD_SUBCOMMANDS = new Set(['list', 'read', 'create', 'edit']);
+const IMPORT_SUBCOMMANDS = new Set(['trello', 'obsidian']);
 const APP_PASSTHROUGH_PREFIXES = ['-psn_'];
 
 function parseArgv(argv) {
@@ -137,6 +142,9 @@ function renderHelpText(commandName = 'signboard') {
     `  ${commandName} settings [--json]`,
     `  ${commandName} settings edit [--tooltips on|off] [--json]`,
     '',
+    `  ${commandName} import trello --file <export.json> [--json]`,
+    `  ${commandName} import obsidian --source <path> [--source <path> ...] [--json]`,
+    '',
     'Board selection:',
     '  `signboard use /path/to/board` stores the current board for later commands',
     '  Use `--board <path>` to override the stored board for a single command',
@@ -164,6 +172,10 @@ function renderHelpText(commandName = 'signboard') {
     '  --remove-label <ref>  edit only',
     '  --move-to <list-ref>  edit only',
     '',
+    'Import options:',
+    '  trello: --file <export.json>',
+    '  obsidian: --source <path> (repeatable, files and directories allowed)',
+    '',
     'Reference matching:',
     '  list refs: directory name or display name, exact or unique partial match',
     '  card refs: filename, 5-char card id, or title, exact or unique partial match',
@@ -189,6 +201,44 @@ async function readBodyOption(options) {
   }
 
   return undefined;
+}
+
+function normalizeImportPath(value, fieldName) {
+  if (value === true || value == null) {
+    throw new Error(`${fieldName} is required.`);
+  }
+
+  const input = String(value || '').trim();
+  if (!input) {
+    throw new Error(`${fieldName} is required.`);
+  }
+
+  return path.resolve(input);
+}
+
+function renderImportSummary(summary) {
+  if (!summary || typeof summary !== 'object') {
+    return 'Import completed.\n';
+  }
+
+  const sourceCount = Array.isArray(summary.sources) ? summary.sources.length : 0;
+  const lines = [
+    `Imported ${sourceCount === 1 ? '1 source' : `${sourceCount} sources`} from ${summary.importer || 'external source'}.`,
+    `${summary.listsCreated || 0} list${summary.listsCreated === 1 ? '' : 's'} created.`,
+    `${summary.cardsCreated || 0} card${summary.cardsCreated === 1 ? '' : 's'} created.`,
+    `${summary.labelsCreated || 0} label${summary.labelsCreated === 1 ? '' : 's'} created.`,
+    `${summary.archivedCards || 0} archived.`,
+  ];
+
+  const warningMessages = Array.isArray(summary.warnings) ? summary.warnings.filter(Boolean) : [];
+  if (warningMessages.length > 0) {
+    lines.push('', 'Warnings:');
+    for (const warningMessage of warningMessages) {
+      lines.push(`- ${warningMessage}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
 }
 
 function renderListsTable(lists) {
@@ -539,6 +589,52 @@ async function runSettingsCommand(action, positionals, options, context) {
   throw new Error(`Unknown settings command: ${action}`);
 }
 
+async function runImportCommand(action, positionals, options, context) {
+  const boardRoot = await resolveBoardRoot(options, context);
+
+  if (!action || !IMPORT_SUBCOMMANDS.has(action)) {
+    throw new Error('Usage: signboard import trello --file <export.json> [--json]\n       signboard import obsidian --source <path> [--source <path> ...] [--json]');
+  }
+
+  if (action === 'trello') {
+    assertAllowedOptions(options, ['file', 'json', 'board'], 'Usage: signboard import trello --file <export.json> [--json]');
+    assertNoExtraPositionals(positionals, 0, 'Usage: signboard import trello --file <export.json> [--json]');
+    const sourcePath = normalizeImportPath(getOption(options, 'file'), '--file');
+    const summary = await importTrello({
+      boardRoot,
+      sourcePath,
+    });
+
+    if (getOption(options, 'json') === true) {
+      context.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+      return 0;
+    }
+
+    context.stdout.write(renderImportSummary(summary));
+    return 0;
+  }
+
+  assertAllowedOptions(options, ['source', 'json', 'board'], 'Usage: signboard import obsidian --source <path> [--source <path> ...] [--json]');
+  assertNoExtraPositionals(positionals, 0, 'Usage: signboard import obsidian --source <path> [--source <path> ...] [--json]');
+  const sourcePaths = getOptionList(options, 'source').map((value) => normalizeImportPath(value, '--source'));
+  if (sourcePaths.length === 0) {
+    throw new Error('At least one --source path is required.');
+  }
+
+  const summary = await importObsidian({
+    boardRoot,
+    sourcePaths,
+  });
+
+  if (getOption(options, 'json') === true) {
+    context.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    return 0;
+  }
+
+  context.stdout.write(renderImportSummary(summary));
+  return 0;
+}
+
 function normalizeCliArgs(argv) {
   return Array.isArray(argv) ? argv.map((value) => String(value)) : [];
 }
@@ -617,6 +713,9 @@ async function runCli(argv, context = {}) {
     if (resource === 'settings') {
       return runSettingsCommand(undefined, [], options, { stdout, stderr, commandName, stateOptions });
     }
+    if (resource === 'import') {
+      throw new Error('Usage: signboard import trello --file <export.json> [--json]\n       signboard import obsidian --source <path> [--source <path> ...] [--json]');
+    }
     const suggestion = getCommandGroupSuggestion(resource);
     throw new Error(
       suggestion
@@ -639,6 +738,10 @@ async function runCli(argv, context = {}) {
 
   if (resource === 'settings') {
     return runSettingsCommand(action, rest, options, { stdout, stderr, commandName, stateOptions });
+  }
+
+  if (resource === 'import') {
+    return runImportCommand(action, rest, options, { stdout, stderr, commandName, stateOptions });
   }
 
   const suggestion = getCommandGroupSuggestion(resource);

--- a/lib/importers/index.js
+++ b/lib/importers/index.js
@@ -1,0 +1,7 @@
+const { importTrello } = require('./trello');
+const { importObsidian } = require('./obsidian');
+
+module.exports = {
+  importTrello,
+  importObsidian,
+};

--- a/lib/importers/obsidian.js
+++ b/lib/importers/obsidian.js
@@ -1,0 +1,873 @@
+const fs = require('fs').promises;
+const path = require('path');
+const cardFrontmatter = require('../cardFrontmatter');
+const {
+  addWarning,
+  appendSections,
+  buildMarkdownSection,
+  buildMetadataBody,
+  collectInlineTags,
+  createCard,
+  createImportContext,
+  createList,
+  ensureLabel,
+  formatLocalIsoDate,
+  normalizeAbsolutePath,
+  normalizeFrontmatterTags,
+  normalizeImportedLabelColors,
+  normalizeIsoDateFromValue,
+  persistLabels,
+  readDirectoryEntries,
+  walkMarkdownFiles,
+} = require('./shared');
+
+const OBSIDIAN_KANBAN_SETTINGS_PATTERN = /%%\s*kanban:settings[\s\S]*?%%/i;
+const OBSIDIAN_KANBAN_FRONTMATTER_PATTERN = /(^|\n)kanban-plugin:\s*board(?:\s|$)/i;
+const TASK_LINE_PATTERN = /^([ \t]*)([-*+])\s+\[([ xX✓✔])\]\s+(.*)$/;
+const TASK_LIST_KANBAN_COLUMN_PATTERN = /#\[([^\]]+)\]/g;
+const CARD_BOARD_DUE_PATTERNS = [
+  { type: 'cardboard', pattern: /@due\(([^)]+)\)/i },
+  { type: 'dataview', pattern: /\[due::\s*([^\]]+)\]/i },
+  { type: 'tasks', pattern: /📅\s*(\d{4}-\d{2}-\d{2})/i },
+  { type: 'kanban', pattern: /@\{(\d{4}-\d{2}-\d{2})\}/i },
+];
+const CARD_BOARD_COMPLETED_PATTERNS = [
+  /@completed\(([^)]+)\)/i,
+  /✅\s*(\d{4}-\d{2}-\d{2}(?:T[0-9:.+-Z]+)?)/i,
+];
+
+function dedupeStrings(values = []) {
+  const results = [];
+  const seen = new Set();
+  for (const value of values) {
+    const normalized = String(value || '').trim();
+    if (!normalized) {
+      continue;
+    }
+
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    results.push(normalized);
+  }
+
+  return results;
+}
+
+function getFileStem(filePath) {
+  return path.basename(String(filePath || ''), path.extname(String(filePath || '')));
+}
+
+function isObsidianKanbanContent(rawContent) {
+  const source = String(rawContent || '');
+  return OBSIDIAN_KANBAN_FRONTMATTER_PATTERN.test(source) || OBSIDIAN_KANBAN_SETTINGS_PATTERN.test(source);
+}
+
+async function readTextFile(filePath) {
+  return fs.readFile(filePath, 'utf8');
+}
+
+function extractTaskColumnTags(text) {
+  const tags = [];
+  let match;
+  const source = String(text || '');
+  while ((match = TASK_LIST_KANBAN_COLUMN_PATTERN.exec(source))) {
+    const tag = String(match[1] || '').trim();
+    if (tag) {
+      tags.push(tag);
+    }
+  }
+
+  return dedupeStrings(tags);
+}
+
+function stripColumnTags(text) {
+  return String(text || '').replace(TASK_LIST_KANBAN_COLUMN_PATTERN, '').replace(/\s+/g, ' ').trim();
+}
+
+function parseDueFromText(text) {
+  const source = String(text || '');
+
+  for (const matcher of CARD_BOARD_DUE_PATTERNS) {
+    const match = source.match(matcher.pattern);
+    if (!match) {
+      continue;
+    }
+
+    const rawValue = String(match[1] || '').trim();
+    if (!rawValue || rawValue.toLowerCase() === 'none') {
+      return {
+        type: matcher.type,
+        raw: rawValue,
+        due: '',
+      };
+    }
+
+    return {
+      type: matcher.type,
+      raw: rawValue,
+      due: normalizeIsoDateFromValue(rawValue),
+    };
+  }
+
+  return null;
+}
+
+function parseCompletedFromText(text) {
+  const source = String(text || '');
+  for (const pattern of CARD_BOARD_COMPLETED_PATTERNS) {
+    const match = source.match(pattern);
+    if (!match) {
+      continue;
+    }
+
+    const rawValue = String(match[1] || '').trim();
+    if (!rawValue) {
+      continue;
+    }
+
+    return {
+      raw: rawValue,
+      iso: normalizeIsoDateFromValue(rawValue),
+    };
+  }
+
+  return null;
+}
+
+function stripConsumedTaskMetadata(text) {
+  return String(text || '')
+    .replace(TASK_LIST_KANBAN_COLUMN_PATTERN, '')
+    .replace(/@\{(\d{4}-\d{2}-\d{2})\}/g, '')
+    .replace(/@due\(([^)]+)\)/gi, '')
+    .replace(/\[due::\s*[^\]]+\]/gi, '')
+    .replace(/📅\s*\d{4}-\d{2}-\d{2}/g, '')
+    .replace(/@completed\(([^)]+)\)/gi, '')
+    .replace(/✅\s*\d{4}-\d{2}-\d{2}(?:T[0-9:.+-Z]+)?/g, '')
+    .replace(/(^|\s)#([A-Za-z0-9/_-]+)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseMarkdownTaskBlocks(rawContent, filePath) {
+  const parsed = cardFrontmatter.parseCardContent(String(rawContent || ''));
+  const body = String(parsed?.body || rawContent || '');
+  const noteTags = normalizeFrontmatterTags(parsed?.frontmatter || {});
+  const fileStem = getFileStem(filePath);
+  const derivedDate = /^\d{4}-\d{2}-\d{2}$/.test(fileStem) ? fileStem : '';
+  const lines = body.split(/\r?\n/);
+  const tasks = [];
+  let currentTask = null;
+
+  function finalizeCurrentTask() {
+    if (!currentTask) {
+      return;
+    }
+
+    currentTask.body = currentTask.bodyLines.join('\n').replace(/\s+$/, '');
+    currentTask.tags = dedupeStrings([
+      ...noteTags,
+      ...collectInlineTags(currentTask.rawLine),
+    ]);
+    currentTask.columnTags = dedupeStrings(extractTaskColumnTags(currentTask.rawLine));
+    currentTask.dueInfo = parseDueFromText(currentTask.rawLine);
+    currentTask.completedInfo = parseCompletedFromText(currentTask.rawLine);
+    currentTask.due = currentTask.dueInfo && currentTask.dueInfo.due
+      ? currentTask.dueInfo.due
+      : derivedDate;
+    currentTask.cleanedTitle = stripConsumedTaskMetadata(currentTask.rawLine);
+    tasks.push(currentTask);
+    currentTask = null;
+  }
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const match = line.match(TASK_LINE_PATTERN);
+    if (match && String(match[1] || '').length === 0) {
+      finalizeCurrentTask();
+      const checkboxValue = String(match[3] || '').replace(/\s+/g, '').toLowerCase();
+      currentTask = {
+        filePath,
+        lineNumber: index + 1,
+        rawLine: String(match[4] || ''),
+        checked: checkboxValue === 'x' || checkboxValue === '✓' || checkboxValue === '✔',
+        bodyLines: [],
+      };
+      continue;
+    }
+
+    if (currentTask) {
+      currentTask.bodyLines.push(line);
+    }
+  }
+
+  finalizeCurrentTask();
+  return tasks;
+}
+
+function buildObsidianMetadataSection(metadata = {}) {
+  return buildMarkdownSection('Imported metadata', buildMetadataBody(metadata));
+}
+
+function prefixListName(sourceName, listName, shouldPrefix) {
+  const baseListName = String(listName || '').trim() || 'Untitled';
+  if (!shouldPrefix) {
+    return baseListName;
+  }
+
+  return `${String(sourceName || 'Imported').trim() || 'Imported'} - ${baseListName}`;
+}
+
+async function ensureLabelsForTags(context, tags = []) {
+  const labelIds = [];
+  const uniqueTags = dedupeStrings(tags);
+  for (const tag of uniqueTags) {
+    const colors = normalizeImportedLabelColors({}, labelIds.length);
+    const labelId = await ensureLabel(context, tag, colors);
+    if (labelId) {
+      labelIds.push(labelId);
+    }
+  }
+
+  return labelIds;
+}
+
+function createTaskBody(task, metadataSection, extraSections = []) {
+  const sections = [];
+  const body = String(task?.body || '').trim();
+  if (body) {
+    sections.push(body);
+  }
+
+  for (const section of extraSections) {
+    if (section) {
+      sections.push(section);
+    }
+  }
+
+  sections.push(metadataSection);
+  return appendSections('', sections);
+}
+
+function parseObsidianKanbanColumns(rawContent, filePath) {
+  const lines = String(rawContent || '').split(/\r?\n/);
+  const columns = [];
+  let currentColumn = null;
+  let currentCard = null;
+
+  function finalizeCard() {
+    if (!currentColumn || !currentCard) {
+      return;
+    }
+
+    currentCard.body = currentCard.bodyLines.join('\n').replace(/\s+$/, '');
+    currentColumn.cards.push(currentCard);
+    currentCard = null;
+  }
+
+  function finalizeColumn() {
+    finalizeCard();
+    if (currentColumn) {
+      columns.push(currentColumn);
+      currentColumn = null;
+    }
+  }
+
+  for (const rawLine of lines) {
+    if (/^##\s+/.test(rawLine)) {
+      finalizeColumn();
+      currentColumn = {
+        name: rawLine.replace(/^##\s+/, '').trim() || 'Untitled',
+        cards: [],
+      };
+      continue;
+    }
+
+    if (!currentColumn) {
+      continue;
+    }
+
+    const match = rawLine.match(TASK_LINE_PATTERN);
+    if (match && String(match[1] || '').length === 0) {
+      finalizeCard();
+      currentCard = {
+        rawLine: String(match[4] || ''),
+        checked: String(match[3] || '').replace(/\s+/g, '').toLowerCase() === 'x',
+        bodyLines: [],
+      };
+      continue;
+    }
+
+    if (currentCard) {
+      currentCard.bodyLines.push(rawLine);
+    }
+  }
+
+  finalizeColumn();
+
+  return columns.map((column) => ({
+    ...column,
+    filePath,
+    cards: column.cards.map((card) => {
+      const dueInfo = parseDueFromText(card.rawLine);
+      const tags = collectInlineTags(card.rawLine);
+      return {
+        ...card,
+        due: dueInfo && dueInfo.due ? dueInfo.due : '',
+        tags,
+        cleanedTitle: stripConsumedTaskMetadata(card.rawLine),
+      };
+    }),
+  }));
+}
+
+async function importObsidianKanbanBoard(context, board, shouldPrefix) {
+  const columns = parseObsidianKanbanColumns(board.rawContent, board.filePath);
+  const createdLists = new Map();
+  const sourceName = board.sourceName;
+
+  for (const column of columns) {
+    const listEntry = await createList(context, prefixListName(sourceName, column.name, shouldPrefix));
+    createdLists.set(column.name, listEntry);
+  }
+
+  for (const column of columns) {
+    const targetList = createdLists.get(column.name);
+    for (const card of column.cards) {
+      const labelIds = await ensureLabelsForTags(context, card.tags);
+      const metadataSection = buildObsidianMetadataSection({
+        Source: 'Obsidian Kanban',
+        'Source board': sourceName,
+        'Source file': board.filePath,
+        'Source column': column.name,
+        'Original card line': card.rawLine,
+        'Completed in source': card.checked ? 'Yes' : '',
+      });
+      const body = createTaskBody(card, metadataSection);
+
+      await createCard(context, targetList, {
+        title: card.cleanedTitle || 'Untitled',
+        due: card.due,
+        labels: labelIds,
+        body,
+      });
+    }
+  }
+}
+
+function extractCardBoardBoardsFromValue(value, results = []) {
+  if (!value || typeof value !== 'object') {
+    return results;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      extractCardBoardBoardsFromValue(entry, results);
+    }
+    return results;
+  }
+
+  if (Array.isArray(value.columns) && typeof value.name === 'string' && value.name.trim()) {
+    results.push(value);
+  }
+
+  for (const entry of Object.values(value)) {
+    extractCardBoardBoardsFromValue(entry, results);
+  }
+
+  return results;
+}
+
+function normalizeCardBoardColumn(rawColumn = {}, index = 0) {
+  const candidateNames = [
+    rawColumn.name,
+    rawColumn.title,
+    rawColumn.label,
+    rawColumn.displayName,
+  ].filter(Boolean);
+  const name = String(candidateNames[0] || `Column ${index + 1}`).trim() || `Column ${index + 1}`;
+  const typeHint = [
+    rawColumn.type,
+    rawColumn.kind,
+    rawColumn.columnType,
+    rawColumn.variant,
+    rawColumn.mode,
+    name,
+  ].filter(Boolean).join(' ').toLowerCase();
+  const tagValue = String(
+    rawColumn.tag ||
+    rawColumn.tagName ||
+    rawColumn.value ||
+    rawColumn.columnTag ||
+    ''
+  ).replace(/^#/, '').trim();
+
+  if (typeHint.includes('completed') || name.toLowerCase() === 'completed') {
+    return { kind: 'completed', name, raw: rawColumn };
+  }
+
+  if (typeHint.includes('untagged')) {
+    return { kind: 'untagged', name, raw: rawColumn };
+  }
+
+  if (typeHint.includes('other') && typeHint.includes('tag')) {
+    return { kind: 'other-tags', name, raw: rawColumn };
+  }
+
+  if (typeHint.includes('undated')) {
+    return { kind: 'undated', name, raw: rawColumn };
+  }
+
+  if (tagValue || typeHint.includes('tag')) {
+    return {
+      kind: 'tag',
+      name,
+      tag: tagValue || name.replace(/^#/, '').trim(),
+      raw: rawColumn,
+    };
+  }
+
+  const from = rawColumn.from ?? rawColumn.start ?? rawColumn.left ?? rawColumn.lower;
+  const to = rawColumn.to ?? rawColumn.end ?? rawColumn.right ?? rawColumn.upper;
+  const before = rawColumn.before ?? rawColumn.max ?? rawColumn.dayBefore;
+  const after = rawColumn.after ?? rawColumn.min ?? rawColumn.dayAfter;
+
+  if (Number.isFinite(Number(from)) && Number.isFinite(Number(to))) {
+    return { kind: 'between', name, from: Number(from), to: Number(to), raw: rawColumn };
+  }
+
+  if (Number.isFinite(Number(before))) {
+    return { kind: 'before', name, before: Number(before), raw: rawColumn };
+  }
+
+  if (Number.isFinite(Number(after))) {
+    return { kind: 'after', name, after: Number(after), raw: rawColumn };
+  }
+
+  if (typeHint.includes('overdue')) {
+    return { kind: 'before', name, before: 0, raw: rawColumn };
+  }
+
+  if (typeHint.includes('tomorrow')) {
+    return { kind: 'between', name, from: 1, to: 1, raw: rawColumn };
+  }
+
+  if (typeHint.includes('today')) {
+    return { kind: 'between', name, from: 0, to: 0, raw: rawColumn };
+  }
+
+  return { kind: 'unknown', name, raw: rawColumn };
+}
+
+function differenceInDays(todayIso, targetIso) {
+  const today = new Date(`${todayIso}T00:00:00`);
+  const target = new Date(`${targetIso}T00:00:00`);
+  if (Number.isNaN(today.getTime()) || Number.isNaN(target.getTime())) {
+    return null;
+  }
+
+  return Math.round((target.getTime() - today.getTime()) / (24 * 60 * 60 * 1000));
+}
+
+function taskMatchesCardBoardColumn(task, column, explicitTagColumns = []) {
+  const tags = Array.isArray(task.tags) ? task.tags.map((entry) => entry.toLowerCase()) : [];
+  const due = String(task.due || '').trim();
+
+  if (column.kind === 'tag') {
+    const target = String(column.tag || '').replace(/^#/, '').toLowerCase();
+    if (!target) {
+      return false;
+    }
+
+    if (target.endsWith('/')) {
+      return tags.some((tag) => tag === target.slice(0, -1) || tag.startsWith(target));
+    }
+
+    return tags.includes(target);
+  }
+
+  if (column.kind === 'untagged') {
+    return tags.length === 0;
+  }
+
+  if (column.kind === 'other-tags') {
+    if (tags.length === 0) {
+      return false;
+    }
+
+    const explicit = explicitTagColumns.map((entry) => String(entry.tag || '').replace(/^#/, '').toLowerCase());
+    return tags.some((tag) => !explicit.some((target) => target && (tag === target || tag.startsWith(`${target}/`))));
+  }
+
+  if (column.kind === 'undated') {
+    return !due;
+  }
+
+  if (!due) {
+    return false;
+  }
+
+  const todayIso = formatLocalIsoDate(new Date());
+  const daysDelta = differenceInDays(todayIso, due);
+  if (daysDelta == null) {
+    return false;
+  }
+
+  if (column.kind === 'between') {
+    return daysDelta >= column.from && daysDelta <= column.to;
+  }
+
+  if (column.kind === 'before') {
+    return daysDelta < column.before;
+  }
+
+  if (column.kind === 'after') {
+    return daysDelta > column.after;
+  }
+
+  return false;
+}
+
+function sortCardBoardTasks(tasks, completed = false) {
+  const sorted = [...tasks];
+  sorted.sort((left, right) => {
+    if (completed) {
+      const leftCompleted = String(left.completedInfo?.raw || '').trim();
+      const rightCompleted = String(right.completedInfo?.raw || '').trim();
+      const completedDelta = rightCompleted.localeCompare(leftCompleted);
+      if (completedDelta !== 0) {
+        return completedDelta;
+      }
+    }
+
+    const dueDelta = String(left.due || '').localeCompare(String(right.due || ''));
+    if (dueDelta !== 0) {
+      return dueDelta;
+    }
+
+    const titleDelta = String(left.cleanedTitle || '').localeCompare(String(right.cleanedTitle || ''));
+    if (titleDelta !== 0) {
+      return titleDelta;
+    }
+
+    const fileDelta = String(left.filePath || '').localeCompare(String(right.filePath || ''));
+    if (fileDelta !== 0) {
+      return fileDelta;
+    }
+
+    return (left.lineNumber || 0) - (right.lineNumber || 0);
+  });
+
+  return sorted;
+}
+
+function buildTaskMetadataSection(task, metadata = {}) {
+  return buildObsidianMetadataSection({
+    ...metadata,
+    'Source file': task.filePath,
+    'Source line': task.lineNumber != null ? String(task.lineNumber) : '',
+    'Original task line': task.rawLine,
+    'Completed in source': task.checked ? 'Yes' : '',
+    'Original due expression': task.dueInfo?.raw || '',
+  });
+}
+
+async function importCardBoardVault(context, source, shouldPrefix) {
+  let config;
+  try {
+    config = JSON.parse(await readTextFile(source.configPath));
+  } catch (error) {
+    addWarning(context, `Unable to parse CardBoard settings at ${source.configPath}: ${error?.message || error}`);
+    return;
+  }
+
+  const boardCandidates = extractCardBoardBoardsFromValue(config)
+    .filter((board) => Array.isArray(board?.columns) && board.columns.length > 0);
+  if (boardCandidates.length === 0) {
+    addWarning(context, `No CardBoard boards were found in ${source.configPath}.`);
+    return;
+  }
+
+  const markdownFiles = (await walkMarkdownFiles(source.rootPath)).filter((filePath) => !source.kanbanFiles.has(filePath));
+  const allTasks = [];
+  for (const filePath of markdownFiles) {
+    const raw = await readTextFile(filePath);
+    allTasks.push(...parseMarkdownTaskBlocks(raw, filePath));
+  }
+
+  for (const board of boardCandidates) {
+    const normalizedColumns = board.columns.map((column, index) => normalizeCardBoardColumn(column, index));
+    const explicitTagColumns = normalizedColumns.filter((column) => column.kind === 'tag');
+    const completedColumn = normalizedColumns.find((column) => column.kind === 'completed') || null;
+    const buckets = new Map();
+
+    for (const column of normalizedColumns) {
+      if (column.kind !== 'completed') {
+        buckets.set(column.name, []);
+      }
+    }
+    if (completedColumn) {
+      buckets.set(completedColumn.name, []);
+    }
+    buckets.set('Unmapped', []);
+
+    for (const task of allTasks) {
+      const matches = normalizedColumns
+        .filter((column) => column.kind !== 'completed')
+        .filter((column) => taskMatchesCardBoardColumn(task, column, explicitTagColumns));
+
+      if (task.checked && completedColumn && matches.length > 0) {
+        buckets.get(completedColumn.name).push(task);
+        continue;
+      }
+
+      if (matches.length > 0) {
+        buckets.get(matches[0].name).push(task);
+        continue;
+      }
+
+      buckets.get('Unmapped').push(task);
+    }
+
+    const sourceName = String(board.name || source.sourceName || 'CardBoard').trim() || 'CardBoard';
+    const createdLists = new Map();
+
+    for (const [columnName, tasks] of buckets.entries()) {
+      if (tasks.length === 0) {
+        continue;
+      }
+
+      const listEntry = await createList(context, prefixListName(sourceName, columnName, shouldPrefix));
+      createdLists.set(columnName, listEntry);
+    }
+
+    for (const [columnName, tasks] of buckets.entries()) {
+      const listEntry = createdLists.get(columnName);
+      if (!listEntry) {
+        continue;
+      }
+
+      const isCompletedColumn = completedColumn && columnName === completedColumn.name;
+      const sortedTasks = sortCardBoardTasks(tasks, isCompletedColumn);
+
+      for (const task of sortedTasks) {
+        const labelIds = await ensureLabelsForTags(context, task.tags);
+        const body = createTaskBody(task, buildTaskMetadataSection(task, {
+          Source: 'Obsidian CardBoard',
+          'Source board': sourceName,
+          'Source column': columnName,
+          'Config file': source.configPath,
+        }));
+
+        await createCard(context, listEntry, {
+          title: task.cleanedTitle || 'Untitled',
+          due: task.due,
+          labels: labelIds,
+          body,
+        });
+      }
+    }
+  }
+}
+
+async function importGenericTaskScope(context, scope, shouldPrefix) {
+  const markdownFiles = Array.isArray(scope.filePaths)
+    ? scope.filePaths
+    : await walkMarkdownFiles(scope.rootPath || scope.filePath || '');
+  const tasks = [];
+
+  for (const filePath of markdownFiles) {
+    if (scope.skipFiles && scope.skipFiles.has(filePath)) {
+      continue;
+    }
+
+    const raw = await readTextFile(filePath);
+    if (isObsidianKanbanContent(raw)) {
+      continue;
+    }
+
+    tasks.push(...parseMarkdownTaskBlocks(raw, filePath));
+  }
+
+  if (tasks.length === 0) {
+    addWarning(context, `No importable markdown tasks were found in ${scope.rootPath || scope.filePath || scope.sourceName}.`);
+    return;
+  }
+
+  const columnOrder = [];
+  const columnTasks = new Map();
+
+  function getOrCreateBucket(name) {
+    if (!columnTasks.has(name)) {
+      columnTasks.set(name, []);
+      columnOrder.push(name);
+    }
+    return columnTasks.get(name);
+  }
+
+  for (const task of tasks) {
+    if (task.checked) {
+      getOrCreateBucket('Done').push(task);
+      continue;
+    }
+
+    if (task.columnTags.length > 0) {
+      getOrCreateBucket(task.columnTags[0]).push(task);
+      continue;
+    }
+
+    const hasExplicitTaskListKanbanColumns = tasks.some((entry) => entry.columnTags.length > 0);
+    getOrCreateBucket(hasExplicitTaskListKanbanColumns ? 'Uncategorised' : 'Tasks').push(task);
+  }
+
+  const createdLists = new Map();
+  for (const columnName of columnOrder) {
+    const listEntry = await createList(context, prefixListName(scope.sourceName, columnName, shouldPrefix));
+    createdLists.set(columnName, listEntry);
+  }
+
+  for (const columnName of columnOrder) {
+    const listEntry = createdLists.get(columnName);
+    const bucket = columnTasks.get(columnName) || [];
+    bucket.sort((left, right) => {
+      const fileDelta = String(left.filePath || '').localeCompare(String(right.filePath || ''));
+      if (fileDelta !== 0) {
+        return fileDelta;
+      }
+      return (left.lineNumber || 0) - (right.lineNumber || 0);
+    });
+
+    for (const task of bucket) {
+      const taskLabels = task.tags.filter((tag) => !task.columnTags.some((columnTag) => columnTag.toLowerCase() === tag.toLowerCase()));
+      const labelIds = await ensureLabelsForTags(context, taskLabels);
+      const body = createTaskBody(task, buildTaskMetadataSection(task, {
+        Source: scope.importerName || 'Obsidian tasks',
+        'Source board': scope.sourceName,
+        'Source column': columnName,
+      }));
+
+      await createCard(context, listEntry, {
+        title: task.cleanedTitle || 'Untitled',
+        due: task.due,
+        labels: labelIds,
+        body,
+      });
+    }
+  }
+}
+
+async function discoverSources(sourcePaths = []) {
+  const normalizedPaths = dedupeStrings(sourcePaths.map((entry) => normalizeAbsolutePath(entry)).filter(Boolean));
+  const kanbanBoards = [];
+  const cardBoardSources = [];
+  const taskScopes = [];
+
+  for (const sourcePath of normalizedPaths) {
+    const stats = await fs.stat(sourcePath);
+    if (stats.isFile()) {
+      const raw = await readTextFile(sourcePath);
+      if (isObsidianKanbanContent(raw)) {
+        kanbanBoards.push({
+          filePath: sourcePath,
+          rawContent: raw,
+          sourceName: getFileStem(sourcePath),
+        });
+      } else {
+        taskScopes.push({
+          filePaths: [sourcePath],
+          sourceName: getFileStem(sourcePath),
+          importerName: 'Obsidian tasks',
+        });
+      }
+      continue;
+    }
+
+    const cardBoardConfigPath = path.join(sourcePath, '.obsidian', 'plugins', 'card-board', 'data.json');
+    const markdownFiles = await walkMarkdownFiles(sourcePath);
+    const kanbanFiles = new Set();
+    const nonKanbanFiles = [];
+
+    for (const filePath of markdownFiles) {
+      const raw = await readTextFile(filePath);
+      if (isObsidianKanbanContent(raw)) {
+        kanbanBoards.push({
+          filePath,
+          rawContent: raw,
+          sourceName: getFileStem(filePath),
+        });
+        kanbanFiles.add(filePath);
+      } else {
+        nonKanbanFiles.push(filePath);
+      }
+    }
+
+    if (await fs.stat(cardBoardConfigPath).then(() => true).catch(() => false)) {
+      cardBoardSources.push({
+        rootPath: sourcePath,
+        configPath: cardBoardConfigPath,
+        sourceName: getFileStem(sourcePath),
+        kanbanFiles,
+      });
+      continue;
+    }
+
+    if (nonKanbanFiles.length > 0) {
+      taskScopes.push({
+        rootPath: sourcePath,
+        filePaths: nonKanbanFiles,
+        sourceName: getFileStem(sourcePath),
+        importerName: 'Obsidian tasks',
+      });
+    }
+  }
+
+  return {
+    kanbanBoards,
+    cardBoardSources,
+    taskScopes,
+  };
+}
+
+async function importObsidian(options = {}) {
+  const sourcePaths = Array.isArray(options.sourcePaths) ? options.sourcePaths.filter(Boolean) : [];
+  if (sourcePaths.length === 0) {
+    throw new Error('At least one Obsidian source path is required.');
+  }
+
+  const context = await createImportContext(options.boardRoot, 'obsidian', sourcePaths);
+  const discovered = await discoverSources(sourcePaths);
+  const totalRecognizedSources =
+    discovered.kanbanBoards.length +
+    discovered.cardBoardSources.length +
+    discovered.taskScopes.length;
+  const shouldPrefix = totalRecognizedSources > 1;
+
+  for (const board of discovered.kanbanBoards) {
+    await importObsidianKanbanBoard(context, board, shouldPrefix);
+  }
+
+  for (const source of discovered.cardBoardSources) {
+    await importCardBoardVault(context, source, shouldPrefix);
+  }
+
+  for (const scope of discovered.taskScopes) {
+    await importGenericTaskScope(context, scope, shouldPrefix);
+  }
+
+  await persistLabels(context);
+  if (totalRecognizedSources === 0) {
+    addWarning(context, 'No supported Obsidian board or task sources were recognized.');
+  }
+
+  return context.summary;
+}
+
+module.exports = {
+  importObsidian,
+  isObsidianKanbanContent,
+  parseMarkdownTaskBlocks,
+  parseObsidianKanbanColumns,
+};

--- a/lib/importers/shared.js
+++ b/lib/importers/shared.js
@@ -1,0 +1,609 @@
+const fs = require('fs').promises;
+const path = require('path');
+const boardLabels = require('../boardLabels');
+const cardFrontmatter = require('../cardFrontmatter');
+const { ARCHIVE_DIRECTORY_NAME } = require('../cliBoard');
+
+const IMPORT_LABEL_COLOR_PALETTE = [
+  { colorLight: '#f59e0b', colorDark: '#d97706' },
+  { colorLight: '#a855f7', colorDark: '#7e22ce' },
+  { colorLight: '#14b8a6', colorDark: '#0f766e' },
+  { colorLight: '#ec4899', colorDark: '#be185d' },
+  { colorLight: '#84cc16', colorDark: '#4d7c0f' },
+  { colorLight: '#f97316', colorDark: '#c2410c' },
+];
+
+const TRELLO_COLOR_MAP = Object.freeze({
+  green: { colorLight: '#22c55e', colorDark: '#16a34a' },
+  yellow: { colorLight: '#eab308', colorDark: '#ca8a04' },
+  orange: { colorLight: '#f97316', colorDark: '#c2410c' },
+  red: { colorLight: '#ef4444', colorDark: '#dc2626' },
+  purple: { colorLight: '#a855f7', colorDark: '#7e22ce' },
+  blue: { colorLight: '#3b82f6', colorDark: '#2563eb' },
+  sky: { colorLight: '#0ea5e9', colorDark: '#0284c7' },
+  lime: { colorLight: '#84cc16', colorDark: '#65a30d' },
+  pink: { colorLight: '#ec4899', colorDark: '#db2777' },
+  black: { colorLight: '#475569', colorDark: '#334155' },
+});
+
+function randomSuffix(length = 5) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let output = '';
+
+  for (let index = 0; index < length; index += 1) {
+    output += alphabet.charAt(Math.floor(Math.random() * alphabet.length));
+  }
+
+  return output;
+}
+
+function zeroPadNumber(value) {
+  return String(Math.max(0, Number(value) || 0)).padStart(3, '0');
+}
+
+function sanitizeListName(rawName) {
+  const cleaned = String(rawName || '')
+    .replace(/[\\/:*?"<>|]/g, '')
+    .replace(/\.\./g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return cleaned || 'Untitled';
+}
+
+function sanitizeCardSlug(rawName) {
+  const cleaned = String(rawName || '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return cleaned || 'untitled';
+}
+
+function slugifyIdentifier(rawValue) {
+  const cleaned = String(rawValue || '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return cleaned || 'item';
+}
+
+function normalizeAbsolutePath(rawPath) {
+  const candidate = String(rawPath || '').trim();
+  return candidate ? path.resolve(candidate) : '';
+}
+
+function formatLocalIsoDate(dateValue) {
+  const date = dateValue instanceof Date ? dateValue : new Date(dateValue);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function normalizeIsoDateFromValue(value) {
+  if (value == null) {
+    return '';
+  }
+
+  const candidate = String(value).trim();
+  if (!candidate) {
+    return '';
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(candidate)) {
+    return candidate;
+  }
+
+  const asDate = new Date(candidate);
+  if (!Number.isNaN(asDate.getTime())) {
+    return formatLocalIsoDate(asDate);
+  }
+
+  return '';
+}
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function readDirectoryEntries(directoryPath) {
+  try {
+    return await fs.readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function getNextListPrefix(boardRoot) {
+  const entries = await readDirectoryEntries(boardRoot);
+  let maxPrefix = -1;
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === ARCHIVE_DIRECTORY_NAME) {
+      continue;
+    }
+
+    const match = String(entry.name).match(/^(\d{3})-/);
+    if (!match) {
+      continue;
+    }
+
+    const prefix = Number(match[1]);
+    if (Number.isFinite(prefix) && prefix > maxPrefix) {
+      maxPrefix = prefix;
+    }
+  }
+
+  return maxPrefix + 1;
+}
+
+async function getNextCardPrefix(listPath) {
+  const entries = await readDirectoryEntries(listPath);
+  let maxPrefix = -1;
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) {
+      continue;
+    }
+
+    const match = String(entry.name).match(/^(\d{3})-/);
+    if (!match) {
+      continue;
+    }
+
+    const prefix = Number(match[1]);
+    if (Number.isFinite(prefix) && prefix > maxPrefix) {
+      maxPrefix = prefix;
+    }
+  }
+
+  return maxPrefix + 1;
+}
+
+function normalizeLabelName(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeHexColor(value, fallback) {
+  const source = String(value || '').trim().toLowerCase();
+  if (!source) {
+    return fallback;
+  }
+
+  if (/^#?[a-f0-9]{3}$/.test(source)) {
+    const compact = source.replace('#', '');
+    return `#${compact[0]}${compact[0]}${compact[1]}${compact[1]}${compact[2]}${compact[2]}`;
+  }
+
+  if (/^#?[a-f0-9]{6}$/.test(source)) {
+    return source.startsWith('#') ? source : `#${source}`;
+  }
+
+  return fallback;
+}
+
+function normalizeImportedLabelColors(rawColors = {}, fallbackIndex = 0) {
+  const fallback = IMPORT_LABEL_COLOR_PALETTE[fallbackIndex % IMPORT_LABEL_COLOR_PALETTE.length];
+  return {
+    colorLight: normalizeHexColor(rawColors.colorLight, fallback.colorLight),
+    colorDark: normalizeHexColor(rawColors.colorDark, fallback.colorDark),
+  };
+}
+
+function getTrelloLabelColors(colorName, fallbackIndex = 0) {
+  const normalized = String(colorName || '').trim().toLowerCase();
+  const mapped = TRELLO_COLOR_MAP[normalized];
+  return normalizeImportedLabelColors(mapped || {}, fallbackIndex);
+}
+
+function createSummary(importer, sourcePaths = []) {
+  return {
+    ok: true,
+    importer,
+    sources: Array.isArray(sourcePaths) ? sourcePaths.map((entry) => String(entry || '')) : [],
+    listsCreated: 0,
+    cardsCreated: 0,
+    labelsCreated: 0,
+    archivedCards: 0,
+    warnings: [],
+  };
+}
+
+async function createImportContext(boardRoot, importer, sourcePaths = []) {
+  const resolvedBoardRoot = normalizeAbsolutePath(boardRoot);
+  if (!resolvedBoardRoot) {
+    throw new Error('Board root is required.');
+  }
+
+  const settings = await boardLabels.readBoardSettings(resolvedBoardRoot, { ensureFile: true });
+  const existingEntries = await readDirectoryEntries(resolvedBoardRoot);
+  const existingListNames = new Set();
+
+  for (const entry of existingEntries) {
+    if (!entry.isDirectory() || entry.name === ARCHIVE_DIRECTORY_NAME) {
+      continue;
+    }
+
+    const match = String(entry.name).match(/^\d{3}-(.*?)-(?:[^-]{5}|stock)$/);
+    if (match && match[1]) {
+      existingListNames.add(String(match[1]).toLowerCase());
+    }
+  }
+
+  const labelNameToId = new Map();
+  const labels = Array.isArray(settings.labels) ? settings.labels.map((label) => ({ ...label })) : [];
+  for (const label of labels) {
+    const normalized = normalizeLabelName(label.name);
+    if (normalized && !labelNameToId.has(normalized)) {
+      labelNameToId.set(normalized, label.id);
+    }
+  }
+
+  return {
+    boardRoot: resolvedBoardRoot,
+    importer,
+    sourcePaths: Array.isArray(sourcePaths) ? sourcePaths.map((entry) => normalizeAbsolutePath(entry)) : [],
+    summary: createSummary(importer, sourcePaths),
+    nextListPrefix: await getNextListPrefix(resolvedBoardRoot),
+    nextCardPrefixByListPath: new Map(),
+    existingListNames,
+    labels,
+    labelNameToId,
+    labelIdSet: new Set(labels.map((label) => String(label.id || ''))),
+    labelsDirty: false,
+  };
+}
+
+function addWarning(context, message) {
+  const warning = String(message || '').trim();
+  if (!warning) {
+    return;
+  }
+
+  if (!context.summary.warnings.includes(warning)) {
+    context.summary.warnings.push(warning);
+  }
+}
+
+function createUniqueLabelId(context, baseName) {
+  const baseId = `import-${slugifyIdentifier(baseName)}`;
+  let candidate = baseId;
+  let suffix = 2;
+
+  while (context.labelIdSet.has(candidate)) {
+    candidate = `${baseId}-${suffix}`;
+    suffix += 1;
+  }
+
+  context.labelIdSet.add(candidate);
+  return candidate;
+}
+
+async function ensureLabel(context, rawName, rawColors = {}) {
+  const labelName = String(rawName || '').trim();
+  if (!labelName) {
+    return '';
+  }
+
+  const normalized = normalizeLabelName(labelName);
+  const existingId = context.labelNameToId.get(normalized);
+  if (existingId) {
+    return existingId;
+  }
+
+  const colors = normalizeImportedLabelColors(rawColors, context.labels.length);
+  const label = {
+    id: createUniqueLabelId(context, labelName),
+    name: labelName,
+    colorLight: colors.colorLight,
+    colorDark: colors.colorDark,
+  };
+
+  context.labels.push(label);
+  context.labelNameToId.set(normalized, label.id);
+  context.labelsDirty = true;
+  context.summary.labelsCreated += 1;
+  return label.id;
+}
+
+async function persistLabels(context) {
+  if (!context.labelsDirty) {
+    return;
+  }
+
+  const nextSettings = await boardLabels.updateBoardSettings(context.boardRoot, {
+    labels: context.labels,
+  });
+  context.labels = Array.isArray(nextSettings.labels) ? nextSettings.labels.map((label) => ({ ...label })) : [];
+  context.labelsDirty = false;
+}
+
+function makeListNameUnique(context, rawName) {
+  const original = sanitizeListName(rawName);
+  let candidate = original;
+  let suffix = 2;
+
+  while (context.existingListNames.has(candidate.toLowerCase())) {
+    candidate = `${original} (${suffix})`;
+    suffix += 1;
+  }
+
+  context.existingListNames.add(candidate.toLowerCase());
+  return candidate;
+}
+
+async function createList(context, rawName) {
+  const displayName = makeListNameUnique(context, rawName);
+  const directoryName = `${zeroPadNumber(context.nextListPrefix)}-${sanitizeListName(displayName)}-${randomSuffix()}`;
+  const listPath = path.join(context.boardRoot, directoryName);
+  context.nextListPrefix += 1;
+  await fs.mkdir(listPath, { recursive: false });
+  context.nextCardPrefixByListPath.set(listPath, 0);
+  context.summary.listsCreated += 1;
+
+  return {
+    displayName,
+    directoryName,
+    path: listPath,
+  };
+}
+
+async function ensureArchiveList(context) {
+  const archivePath = path.join(context.boardRoot, ARCHIVE_DIRECTORY_NAME);
+  if (!(await pathExists(archivePath))) {
+    await fs.mkdir(archivePath, { recursive: true });
+  }
+
+  if (!context.nextCardPrefixByListPath.has(archivePath)) {
+    context.nextCardPrefixByListPath.set(archivePath, await getNextCardPrefix(archivePath));
+  }
+
+  return {
+    displayName: 'Archive',
+    directoryName: ARCHIVE_DIRECTORY_NAME,
+    path: archivePath,
+  };
+}
+
+async function getNextCardPrefixForList(context, listPath) {
+  if (context.nextCardPrefixByListPath.has(listPath)) {
+    const nextPrefix = context.nextCardPrefixByListPath.get(listPath);
+    context.nextCardPrefixByListPath.set(listPath, nextPrefix + 1);
+    return nextPrefix;
+  }
+
+  const nextPrefix = await getNextCardPrefix(listPath);
+  context.nextCardPrefixByListPath.set(listPath, nextPrefix + 1);
+  return nextPrefix;
+}
+
+function normalizeSectionBody(body) {
+  const text = typeof body === 'string' ? body.replace(/\s+$/, '') : '';
+  return text.trim() ? text.replace(/^\n+/, '') : '';
+}
+
+function buildMarkdownSection(title, body) {
+  const normalizedBody = normalizeSectionBody(body);
+  if (!normalizedBody) {
+    return '';
+  }
+
+  return `## ${String(title || '').trim()}\n\n${normalizedBody}`;
+}
+
+function buildMetadataBody(metadata = {}) {
+  const lines = [];
+  for (const [key, value] of Object.entries(metadata || {})) {
+    if (value == null) {
+      continue;
+    }
+
+    if (Array.isArray(value) && value.length === 0) {
+      continue;
+    }
+
+    const label = String(key || '').trim();
+    if (!label) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      lines.push(`- **${label}:** ${value.join(', ')}`);
+      continue;
+    }
+
+    const normalized = String(value).trim();
+    if (!normalized) {
+      continue;
+    }
+
+    lines.push(`- **${label}:** ${normalized}`);
+  }
+
+  return lines.join('\n');
+}
+
+function appendSections(baseBody = '', sections = []) {
+  const parts = [];
+  const normalizedBase = normalizeSectionBody(baseBody);
+  if (normalizedBase) {
+    parts.push(normalizedBase);
+  }
+
+  for (const section of Array.isArray(sections) ? sections : []) {
+    const normalized = normalizeSectionBody(section);
+    if (normalized) {
+      parts.push(normalized);
+    }
+  }
+
+  return parts.join('\n\n');
+}
+
+async function createCard(context, listEntry, card = {}) {
+  const targetList = listEntry && listEntry.path ? listEntry : await ensureArchiveList(context);
+  const title = String(card.title || '').trim() || 'Untitled';
+  const nextPrefix = await getNextCardPrefixForList(context, targetList.path);
+  const fileName = `${zeroPadNumber(nextPrefix)}-${sanitizeCardSlug(title).slice(0, 40)}-${randomSuffix()}.md`;
+  const filePath = path.join(targetList.path, fileName);
+  const normalizedFrontmatter = {
+    title,
+    due: normalizeIsoDateFromValue(card.due),
+    labels: Array.isArray(card.labels) ? card.labels.filter(Boolean) : [],
+  };
+
+  await cardFrontmatter.writeCard(filePath, {
+    frontmatter: normalizedFrontmatter,
+    body: typeof card.body === 'string' ? card.body : '',
+  });
+
+  context.summary.cardsCreated += 1;
+  if (targetList.directoryName === ARCHIVE_DIRECTORY_NAME) {
+    context.summary.archivedCards += 1;
+  }
+
+  return {
+    filePath,
+    fileName,
+    listPath: targetList.path,
+  };
+}
+
+async function walkMarkdownFiles(rootPath, options = {}) {
+  const ignoreNames = new Set(Array.isArray(options.ignoreNames) ? options.ignoreNames : ['.git', '.obsidian', 'node_modules']);
+  const results = [];
+  const resolvedRoot = normalizeAbsolutePath(rootPath);
+  if (!resolvedRoot) {
+    return results;
+  }
+
+  const stats = await fs.stat(resolvedRoot);
+  if (stats.isFile()) {
+    if (resolvedRoot.endsWith('.md')) {
+      results.push(resolvedRoot);
+    }
+    return results;
+  }
+
+  const queue = [resolvedRoot];
+  while (queue.length > 0) {
+    const currentPath = queue.shift();
+    const entries = await readDirectoryEntries(currentPath);
+    for (const entry of entries) {
+      if (ignoreNames.has(entry.name)) {
+        continue;
+      }
+
+      const nextPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(nextPath);
+        continue;
+      }
+
+      if (entry.isFile() && entry.name.endsWith('.md')) {
+        results.push(nextPath);
+      }
+    }
+  }
+
+  return results.sort((left, right) => left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' }));
+}
+
+function normalizeFrontmatterTags(frontmatter = {}) {
+  const values = [];
+  const source = frontmatter && typeof frontmatter === 'object' ? frontmatter : {};
+  const candidates = [source.tags, source.tag];
+
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      values.push(...candidate);
+      continue;
+    }
+
+    if (typeof candidate === 'string') {
+      values.push(...candidate.split(','));
+    }
+  }
+
+  const normalized = [];
+  const seen = new Set();
+  for (const value of values) {
+    const tag = String(value || '').trim().replace(/^#/, '');
+    if (!tag) {
+      continue;
+    }
+
+    const key = tag.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalized.push(tag);
+  }
+
+  return normalized;
+}
+
+function collectInlineTags(text) {
+  const matches = [];
+  const pattern = /(^|\s)#([A-Za-z0-9/_-]+)/g;
+  let match;
+  while ((match = pattern.exec(String(text || '')))) {
+    matches.push(match[2]);
+  }
+  return matches;
+}
+
+module.exports = {
+  ARCHIVE_DIRECTORY_NAME,
+  appendSections,
+  addWarning,
+  buildMarkdownSection,
+  buildMetadataBody,
+  collectInlineTags,
+  createCard,
+  createImportContext,
+  createList,
+  createSummary,
+  ensureArchiveList,
+  ensureLabel,
+  formatLocalIsoDate,
+  getTrelloLabelColors,
+  normalizeAbsolutePath,
+  normalizeFrontmatterTags,
+  normalizeHexColor,
+  normalizeImportedLabelColors,
+  normalizeIsoDateFromValue,
+  pathExists,
+  persistLabels,
+  randomSuffix,
+  readDirectoryEntries,
+  sanitizeCardSlug,
+  sanitizeListName,
+  slugifyIdentifier,
+  walkMarkdownFiles,
+};

--- a/lib/importers/trello.js
+++ b/lib/importers/trello.js
@@ -1,0 +1,281 @@
+const fs = require('fs').promises;
+const {
+  addWarning,
+  appendSections,
+  buildMarkdownSection,
+  buildMetadataBody,
+  createCard,
+  createImportContext,
+  createList,
+  ensureLabel,
+  getTrelloLabelColors,
+  normalizeIsoDateFromValue,
+  persistLabels,
+} = require('./shared');
+
+function sortByPosition(left, right) {
+  return (Number(left?.pos) || 0) - (Number(right?.pos) || 0);
+}
+
+function buildChecklistSection(checklists = []) {
+  const sections = [];
+
+  for (const checklist of checklists) {
+    const items = Array.isArray(checklist.checkItems) ? [...checklist.checkItems].sort(sortByPosition) : [];
+    if (items.length === 0) {
+      continue;
+    }
+
+    const lines = items.map((item) => {
+      const due = normalizeIsoDateFromValue(item.due);
+      const checkbox = item.state === 'complete' ? '[x]' : '[ ]';
+      const duePrefix = due ? `(due: ${due}) ` : '';
+      return `- ${checkbox} ${duePrefix}${String(item.name || '').trim() || 'Untitled task'}`;
+    });
+
+    sections.push(buildMarkdownSection(String(checklist.name || 'Checklist').trim() || 'Checklist', lines.join('\n')));
+  }
+
+  return sections;
+}
+
+function buildCommentsSection(actions = []) {
+  if (!Array.isArray(actions) || actions.length === 0) {
+    return '';
+  }
+
+  const lines = [];
+  const sorted = [...actions].sort((left, right) => {
+    return String(left?.date || '').localeCompare(String(right?.date || ''));
+  });
+
+  for (const action of sorted) {
+    const text = String(action?.data?.text || '').trim();
+    if (!text) {
+      continue;
+    }
+
+    const author = String(action?.memberCreator?.fullName || action?.memberCreator?.username || 'Unknown').trim();
+    const date = String(action?.date || '').trim();
+    lines.push(`- ${date}${author ? ` by ${author}` : ''}`);
+    lines.push(`  ${text.replace(/\n/g, '\n  ')}`);
+  }
+
+  return lines.length > 0 ? buildMarkdownSection('Imported comments', lines.join('\n')) : '';
+}
+
+function buildAttachmentsSection(attachments = []) {
+  if (!Array.isArray(attachments) || attachments.length === 0) {
+    return '';
+  }
+
+  const lines = attachments.map((attachment) => {
+    const name = String(attachment?.name || attachment?.fileName || 'Attachment').trim() || 'Attachment';
+    const url = String(attachment?.url || '').trim();
+    const details = [];
+    if (attachment?.mimeType) {
+      details.push(String(attachment.mimeType));
+    }
+    if (Number.isFinite(attachment?.bytes)) {
+      details.push(`${attachment.bytes} bytes`);
+    }
+
+    const suffix = details.length > 0 ? ` (${details.join(', ')})` : '';
+    return url ? `- [${name}](${url})${suffix}` : `- ${name}${suffix}`;
+  });
+
+  return buildMarkdownSection('Imported attachments', lines.join('\n'));
+}
+
+function buildMetadataSection(board, list, card, members = []) {
+  const metadata = {
+    Source: 'Trello',
+    'Trello board': board?.name || '',
+    'Trello board URL': board?.url || board?.shortUrl || '',
+    'Original Trello list': list?.name || 'Unknown list',
+    'Trello card URL': card?.url || card?.shortUrl || '',
+    'Trello card ID': card?.id || '',
+    'Trello card short ID': card?.idShort != null ? String(card.idShort) : '',
+    'Trello short link': card?.shortLink || '',
+    'Closed in Trello': card?.closed === true || list?.closed === true ? 'Yes' : '',
+    'Template': card?.isTemplate === true ? 'Yes' : '',
+    Start: card?.start || '',
+    'Due timestamp': card?.due || '',
+    'Due complete': card?.dueComplete === true ? 'Yes' : '',
+    'Due reminder': card?.dueReminder != null ? String(card.dueReminder) : '',
+    Members: members,
+    'Last activity': card?.dateLastActivity || '',
+  };
+
+  return buildMarkdownSection('Imported metadata', buildMetadataBody(metadata));
+}
+
+function getUsedTrelloLabelIds(cards = []) {
+  const used = new Set();
+  for (const card of cards) {
+    const labelIds = Array.isArray(card?.idLabels) ? card.idLabels : [];
+    for (const labelId of labelIds) {
+      if (labelId) {
+        used.add(String(labelId));
+      }
+    }
+  }
+  return used;
+}
+
+function resolveCardMembers(card, memberMap) {
+  const ids = Array.isArray(card?.idMembers) ? card.idMembers : [];
+  const names = [];
+  for (const id of ids) {
+    const member = memberMap.get(String(id));
+    if (!member) {
+      continue;
+    }
+
+    const display = String(member.fullName || member.username || member.id || '').trim();
+    if (display) {
+      names.push(display);
+    }
+  }
+
+  return names;
+}
+
+async function buildLabelIdMap(context, data) {
+  const labelIdMap = new Map();
+  const cards = Array.isArray(data.cards) ? data.cards : [];
+  const usedLabelIds = getUsedTrelloLabelIds(cards);
+  const labels = Array.isArray(data.labels) ? data.labels : [];
+
+  for (const label of labels) {
+    const rawName = String(label?.name || '').trim();
+    if (!rawName && !usedLabelIds.has(String(label?.id || ''))) {
+      continue;
+    }
+
+    const name = rawName || `Trello ${String(label?.color || 'Label').trim().replace(/^./, (char) => char.toUpperCase())}`;
+    const labelId = await ensureLabel(context, name, getTrelloLabelColors(label?.color, labelIdMap.size));
+    if (labelId) {
+      labelIdMap.set(String(label.id || ''), labelId);
+    }
+  }
+
+  await persistLabels(context);
+  return labelIdMap;
+}
+
+async function importTrello(options = {}) {
+  const sourcePath = String(options.sourcePath || '').trim();
+  if (!sourcePath) {
+    throw new Error('Trello import source path is required.');
+  }
+
+  const raw = await fs.readFile(sourcePath, 'utf8');
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Invalid Trello JSON export: ${error?.message || error}`);
+  }
+
+  if (!data || !Array.isArray(data.cards) || !Array.isArray(data.lists)) {
+    throw new Error('Invalid Trello export. Expected board JSON with cards and lists arrays.');
+  }
+
+  const context = await createImportContext(options.boardRoot, 'trello', [sourcePath]);
+  const labelIdMap = await buildLabelIdMap(context, data);
+  const memberMap = new Map((Array.isArray(data.members) ? data.members : []).map((member) => [String(member.id || ''), member]));
+  const listEntries = [...data.lists].sort(sortByPosition);
+  const listById = new Map(listEntries.map((list) => [String(list.id || ''), list]));
+  const checklistMap = new Map();
+  const actionMap = new Map();
+  const createdOpenLists = new Map();
+
+  if (Array.isArray(data.checklists)) {
+    for (const checklist of data.checklists) {
+      const key = String(checklist?.idCard || '');
+      if (!key) {
+        continue;
+      }
+
+      if (!checklistMap.has(key)) {
+        checklistMap.set(key, []);
+      }
+      checklistMap.get(key).push(checklist);
+    }
+  }
+
+  if (Array.isArray(data.actions)) {
+    if (data.actions.length >= 1000) {
+      addWarning(context, 'This Trello export includes 1000 actions, so older comments/history may be missing.');
+    }
+
+    for (const action of data.actions) {
+      if (action?.type !== 'commentCard') {
+        continue;
+      }
+
+      const cardId = String(action?.data?.idCard || '');
+      if (!cardId) {
+        continue;
+      }
+
+      if (!actionMap.has(cardId)) {
+        actionMap.set(cardId, []);
+      }
+      actionMap.get(cardId).push(action);
+    }
+  }
+
+  for (const list of listEntries) {
+    if (list?.closed === true) {
+      continue;
+    }
+
+    const created = await createList(context, list?.name || 'Untitled');
+    createdOpenLists.set(String(list.id || ''), created);
+  }
+
+  const sortedCards = [...data.cards].sort((left, right) => {
+    const leftList = listById.get(String(left?.idList || ''));
+    const rightList = listById.get(String(right?.idList || ''));
+    const listDelta = sortByPosition(leftList, rightList);
+    if (listDelta !== 0) {
+      return listDelta;
+    }
+
+    return sortByPosition(left, right);
+  });
+
+  for (const card of sortedCards) {
+    const sourceList = listById.get(String(card?.idList || '')) || null;
+    const isArchived = card?.closed === true || sourceList?.closed === true;
+    const targetList = isArchived
+      ? null
+      : createdOpenLists.get(String(card?.idList || ''));
+    const cardLabelIds = Array.isArray(card?.idLabels)
+      ? card.idLabels.map((id) => labelIdMap.get(String(id || ''))).filter(Boolean)
+      : [];
+    const cardMembers = resolveCardMembers(card, memberMap);
+    const body = appendSections(String(card?.desc || '').trim(), [
+      ...buildChecklistSection(checklistMap.get(String(card?.id || '')) || []),
+      buildCommentsSection(actionMap.get(String(card?.id || '')) || []),
+      buildAttachmentsSection(card?.attachments || []),
+      buildMetadataSection(data, sourceList, card, cardMembers),
+    ]);
+
+    await createCard(context, targetList, {
+      title: card?.name || 'Untitled',
+      due: normalizeIsoDateFromValue(card?.due),
+      labels: cardLabelIds,
+      body,
+    });
+  }
+
+  await persistLabels(context);
+  return context.summary;
+}
+
+module.exports = {
+  importTrello,
+};

--- a/lib/mcpServer.js
+++ b/lib/mcpServer.js
@@ -3,6 +3,10 @@ const path = require('path');
 const cardFrontmatter = require('./cardFrontmatter');
 const boardLabels = require('./boardLabels');
 const { insertCardFileAtTop } = require('./cardOrdering');
+const {
+  importTrello,
+  importObsidian,
+} = require('./importers');
 
 const JSON_RPC_VERSION = '2.0';
 const MCP_PROTOCOL_VERSION = '2025-11-25';
@@ -299,6 +303,36 @@ const TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    name: 'signboard.import_trello',
+    description: 'Import a Trello board JSON export into an existing Signboard board.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['boardRoot', 'sourcePath'],
+      properties: {
+        boardRoot: { type: 'string', description: 'Absolute board root path on disk.' },
+        sourcePath: { type: 'string', description: 'Absolute path to a Trello JSON export file.' },
+      },
+    },
+  },
+  {
+    name: 'signboard.import_obsidian',
+    description: 'Import Obsidian markdown files and/or directories into an existing Signboard board.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['boardRoot', 'sourcePaths'],
+      properties: {
+        boardRoot: { type: 'string', description: 'Absolute board root path on disk.' },
+        sourcePaths: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Absolute paths to markdown files and/or directories to import.',
+        },
+      },
+    },
+  },
 ];
 
 class JsonRpcError extends Error {
@@ -481,6 +515,40 @@ async function ensureExistingDirectory(directoryPath, message) {
   }
 }
 
+async function ensureExistingFile(filePath, message) {
+  let stats;
+
+  try {
+    stats = await fs.stat(filePath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(message || `File does not exist: ${filePath}`);
+    }
+    throw error;
+  }
+
+  if (!stats.isFile()) {
+    throw new Error(message || `Path is not a file: ${filePath}`);
+  }
+}
+
+async function ensureExistingFileOrDirectory(targetPath, message) {
+  let stats;
+
+  try {
+    stats = await fs.stat(targetPath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(message || `Path does not exist: ${targetPath}`);
+    }
+    throw error;
+  }
+
+  if (!stats.isFile() && !stats.isDirectory()) {
+    throw new Error(message || `Path must be a file or directory: ${targetPath}`);
+  }
+}
+
 async function pathExists(filePath) {
   try {
     await fs.access(filePath);
@@ -535,6 +603,20 @@ async function resolveExistingDirectoryPath(config, directoryPathInput, fieldNam
   await ensureExistingDirectory(resolvedDirectoryPath, `${fieldName} does not exist: ${resolvedDirectoryPath}`);
   assertInsideAllowedRoots(config, resolvedDirectoryPath, fieldName);
   return resolvedDirectoryPath;
+}
+
+async function resolveExistingFilePath(config, filePathInput, fieldName) {
+  const resolvedFilePath = resolveAbsolutePathInput(filePathInput, fieldName);
+  await ensureExistingFile(resolvedFilePath, `${fieldName} does not exist: ${resolvedFilePath}`);
+  assertInsideAllowedRoots(config, resolvedFilePath, fieldName);
+  return resolvedFilePath;
+}
+
+async function resolveExistingImportSourcePath(config, sourcePathInput, fieldName) {
+  const resolvedSourcePath = resolveAbsolutePathInput(sourcePathInput, fieldName);
+  await ensureExistingFileOrDirectory(resolvedSourcePath, `${fieldName} does not exist: ${resolvedSourcePath}`);
+  assertInsideAllowedRoots(config, resolvedSourcePath, fieldName);
+  return resolvedSourcePath;
 }
 
 function normalizeCardBodyInput(value) {
@@ -1383,6 +1465,46 @@ async function handleToolCall(config, name, args = {}) {
         ok: true,
         boardRoot,
         settings,
+      };
+    }
+
+    case 'signboard.import_trello': {
+      assertWriteAllowed(config, 'signboard.import_trello');
+
+      const boardRoot = await resolveBoardRoot(config, args.boardRoot);
+      const sourcePath = await resolveExistingFilePath(config, args.sourcePath, 'sourcePath');
+      const summary = await importTrello({
+        boardRoot,
+        sourcePath,
+      });
+
+      return {
+        boardRoot,
+        ...summary,
+      };
+    }
+
+    case 'signboard.import_obsidian': {
+      assertWriteAllowed(config, 'signboard.import_obsidian');
+
+      const boardRoot = await resolveBoardRoot(config, args.boardRoot);
+      if (!Array.isArray(args.sourcePaths) || args.sourcePaths.length === 0) {
+        throw new Error('sourcePaths must be a non-empty array of absolute paths.');
+      }
+
+      const sourcePaths = [];
+      for (let index = 0; index < args.sourcePaths.length; index += 1) {
+        sourcePaths.push(await resolveExistingImportSourcePath(config, args.sourcePaths[index], `sourcePaths[${index}]`));
+      }
+
+      const summary = await importObsidian({
+        boardRoot,
+        sourcePaths,
+      });
+
+      return {
+        boardRoot,
+        ...summary,
       };
     }
 

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ const fsPromises = fs.promises;
 const path = require('path');
 const { pathToFileURL } = require('url');
 const cardFrontmatter = require('./lib/cardFrontmatter');
+const { archiveCard, archiveList } = require('./lib/archive');
 const boardLabels = require('./lib/boardLabels');
 const { importTrello, importObsidian } = require('./lib/importers');
 const { startSignboardMcpServer } = require('./lib/mcpServer');
@@ -1924,6 +1925,18 @@ ipcMain.handle('board-call', async (event, payload = {}) => {
       });
 
       return { ok: true };
+    }
+
+    case 'archiveCard': {
+      const filePath = requireWritablePath(event.sender, args[0]);
+      const senderState = getSenderBoardAccessState(event.sender);
+      return archiveCard(senderState.activeBoardRoot, filePath);
+    }
+
+    case 'archiveList': {
+      const listPath = requireWritablePath(event.sender, args[0]);
+      const senderState = getSenderBoardAccessState(event.sender);
+      return archiveList(senderState.activeBoardRoot, listPath);
     }
 
     case 'moveCard':

--- a/main.js
+++ b/main.js
@@ -68,6 +68,16 @@ function getUserArgsFromProcessArgv(argv = process.argv) {
     return argv.slice(2);
   }
 
+  if (secondArg) {
+    try {
+      if (fs.statSync(secondArg).isDirectory()) {
+        return argv.slice(2);
+      }
+    } catch {
+      // Ignore values that are not filesystem paths.
+    }
+  }
+
   return argv.slice(1);
 }
 

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ const path = require('path');
 const { pathToFileURL } = require('url');
 const cardFrontmatter = require('./lib/cardFrontmatter');
 const boardLabels = require('./lib/boardLabels');
+const { importTrello, importObsidian } = require('./lib/importers');
 const { startSignboardMcpServer } = require('./lib/mcpServer');
 const { isCliInvocation, runCli } = require('./lib/cliApp');
 const { installCliForCurrentUser } = require('./lib/cliInstall');
@@ -450,9 +451,9 @@ function cleanupSenderBoardState(senderId) {
   pendingDirectorySelectionsBySender.delete(senderId);
 }
 
-function storePendingDirectorySelection(sender, directoryPath) {
-  const normalizedDirectory = normalizeAbsolutePath(directoryPath);
-  if (!normalizedDirectory) {
+function storePendingSelection(sender, targetPath, kind = 'path') {
+  const normalizedTargetPath = normalizeAbsolutePath(targetPath);
+  if (!normalizedTargetPath) {
     return '';
   }
 
@@ -467,14 +468,15 @@ function storePendingDirectorySelection(sender, directoryPath) {
   }
 
   selections.set(token, {
-    path: normalizedDirectory,
+    path: normalizedTargetPath,
+    kind,
     expiresAt: now + DIRECTORY_SELECTION_MAX_AGE_MS,
   });
 
   return token;
 }
 
-function consumePendingDirectorySelection(sender, token) {
+function consumePendingSelection(sender, token, expectedKinds = []) {
   const selectionToken = typeof token === 'string' ? token.trim() : '';
   if (!selectionToken) {
     return '';
@@ -488,7 +490,20 @@ function consumePendingDirectorySelection(sender, token) {
     return '';
   }
 
+  const allowedKinds = Array.isArray(expectedKinds) ? expectedKinds : [];
+  if (allowedKinds.length > 0 && !allowedKinds.includes(selection.kind)) {
+    return '';
+  }
+
   return normalizeAbsolutePath(selection.path);
+}
+
+function storePendingDirectorySelection(sender, directoryPath) {
+  return storePendingSelection(sender, directoryPath, 'directory');
+}
+
+function consumePendingDirectorySelection(sender, token) {
+  return consumePendingSelection(sender, token, ['directory']);
 }
 
 function resolveReadableBoardRoot(sender, boardRoot) {
@@ -1950,64 +1965,34 @@ ipcMain.handle('board-call', async (event, payload = {}) => {
       return { ok: true };
     }
 
-    case 'importFromTrello': {
+    case 'importTrello': {
       const boardRoot = requireWritableBoardRoot(event.sender, args[0]);
-      const entries = await fsPromises.readdir(boardRoot, { withFileTypes: true });
-      if (entries.some((entry) => entry.isDirectory())) {
-        return { ok: true, imported: false };
+      const sourcePath = consumePendingSelection(event.sender, args[1], ['file']);
+      if (!sourcePath) {
+        throw new Error('INVALID_SELECTION_TOKEN');
       }
 
-      const jsonPath = path.join(boardRoot, 'trello.json');
-      try {
-        await fsPromises.access(jsonPath, fs.constants.F_OK);
-      } catch {
-        return { ok: true, imported: false };
+      return importTrello({
+        boardRoot,
+        sourcePath,
+      });
+    }
+
+    case 'importObsidian': {
+      const boardRoot = requireWritableBoardRoot(event.sender, args[0]);
+      const selectionTokens = Array.isArray(args[1]) ? args[1] : [];
+      const sourcePaths = selectionTokens
+        .map((token) => consumePendingSelection(event.sender, token, ['file', 'directory']))
+        .filter(Boolean);
+
+      if (sourcePaths.length === 0) {
+        throw new Error('INVALID_SELECTION_TOKEN');
       }
 
-      const raw = await fsPromises.readFile(jsonPath, 'utf8');
-      const data = JSON.parse(raw);
-      if (!Array.isArray(data.cards) || !Array.isArray(data.lists)) {
-        throw new Error('INVALID_TRELLO_EXPORT');
-      }
-
-      const listMap = {};
-      const cardsByList = {};
-
-      for (const list of data.lists) {
-        listMap[list.id] = list.name;
-      }
-
-      for (const card of data.cards) {
-        const listName = listMap[card.idList] || 'UnknownList';
-        if (!cardsByList[listName]) {
-          cardsByList[listName] = [];
-        }
-        cardsByList[listName].push(card);
-      }
-
-      let listCount = 0;
-      for (const [listName, cards] of Object.entries(cardsByList)) {
-        const listNumber = listCount.toString().padStart(3, '0');
-        const folder = path.join(boardRoot, `${listNumber}-${sanitizeImportedName(listName)}-trelo`);
-        await fsPromises.mkdir(folder, { recursive: true });
-        listCount += 1;
-
-        cards.sort((left, right) => (left.pos ?? 0) - (right.pos ?? 0));
-
-        for (const [index, card] of cards.entries()) {
-          const number = String(index + 1).padStart(3, '0');
-          const fileName = `${number}-${await sanitizeImportedCardFileName(card.name)}-${importedRandomSuffix()}.md`;
-          const filePath = path.join(folder, fileName);
-
-          await cardFrontmatter.writeCard(filePath, {
-            frontmatter: { title: escapeMarkdownTitle(card.name) },
-            body: card.desc || '',
-          });
-        }
-      }
-
-      await fsPromises.mkdir(path.join(boardRoot, 'XXX-Archive'), { recursive: true });
-      return { ok: true, imported: true };
+      return importObsidian({
+        boardRoot,
+        sourcePaths,
+      });
     }
 
     default:
@@ -2037,6 +2022,49 @@ ipcMain.handle('choose-directory', async (event, { defaultPath } = {}) => {
     path: selectedPath,
     token: storePendingDirectorySelection(event.sender, selectedPath),
   };
+});
+
+ipcMain.handle('pick-import-sources', async (event, { importer, defaultPath } = {}) => {
+  const normalizedImporter = importer === 'trello' ? 'trello' : 'obsidian';
+  const result = await dialog.showOpenDialog({
+    title: normalizedImporter === 'trello' ? 'Select Trello JSON export' : 'Select Obsidian files or folder',
+    buttonLabel: normalizedImporter === 'trello' ? 'Choose JSON' : 'Choose Sources',
+    defaultPath,
+    filters: normalizedImporter === 'trello'
+      ? [{ name: 'JSON', extensions: ['json'] }]
+      : [{ name: 'Markdown', extensions: ['md', 'markdown'] }],
+    properties: normalizedImporter === 'trello'
+      ? ['openFile']
+      : ['openFile', 'openDirectory', 'multiSelections'],
+  });
+
+  if (result.canceled) {
+    return null;
+  }
+
+  const selections = [];
+  for (const rawPath of result.filePaths || []) {
+    const selectedPath = normalizeAbsolutePath(rawPath);
+    if (!selectedPath) {
+      continue;
+    }
+
+    let stats = null;
+    try {
+      stats = await fsPromises.stat(selectedPath);
+    } catch {
+      continue;
+    }
+
+    const kind = stats.isDirectory() ? 'directory' : 'file';
+    selections.push({
+      path: selectedPath,
+      kind,
+      token: storePendingSelection(event.sender, selectedPath, kind),
+    });
+  }
+
+  return selections;
 });
 
 ipcMain.handle('share-file', async (event, filePath) => {

--- a/main.js
+++ b/main.js
@@ -1749,7 +1749,7 @@ function buildApplicationMenu() {
   });
 
   template.push({
-    role: 'help',
+    label: 'Help',
     submenu: [
       !isMac ? createAboutSignboardMenuItem() : null,
       !isMac ? createCheckForUpdatesMenuItem() : null,

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 /*!
  * Signboard - A local-first Kanban app that writes Markdown
- * Copyright (c) 2025 Colin Devroe - cdevroe.com
+ * Copyright (c) 2025-2026 Colin Devroe - cdevroe.com
  * Licensed under the MIT License. See LICENSE file for details.
  */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signboard",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signboard",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:board-views": "node scripts/test-board-views.js",
     "test:due-notifications": "node scripts/test-due-notifications.js",
     "test:task-list": "node scripts/test-task-list-parser.js",
+    "test:archive": "node scripts/test-archive.js",
     "test:import-trello": "node scripts/test-import-trello.js",
     "test:import-obsidian": "node scripts/test-import-obsidian.js",
     "test:timestamp": "node scripts/test-timestamp-format.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signboard",
   "productName": "Signboard",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Colin Devroe <colin@cdevroe.com> (https://cdevroe.com)",
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "test:board-views": "node scripts/test-board-views.js",
     "test:due-notifications": "node scripts/test-due-notifications.js",
     "test:task-list": "node scripts/test-task-list-parser.js",
+    "test:import-trello": "node scripts/test-import-trello.js",
+    "test:import-obsidian": "node scripts/test-import-obsidian.js",
     "test:timestamp": "node scripts/test-timestamp-format.js",
     "test:playwright": "npm run build:js && playwright test",
     "migrate:legacy-cards": "node scripts/migrate-legacy-cards.js",

--- a/preload.js
+++ b/preload.js
@@ -49,6 +49,8 @@ contextBridge.exposeInMainWorld('board', {
   updateBoardSettings: async (boardRoot, partialSettings) =>
     invokeBoard('updateBoardSettings', boardRoot, partialSettings),
   createCard: async (filePath, content) => invokeBoard('createCard', filePath, content),
+  archiveCard: async (filePath) => invokeBoard('archiveCard', filePath),
+  archiveList: async (listPath) => invokeBoard('archiveList', listPath),
   moveCard: async (src, dst) => invokeBoard('moveCard', src, dst),
   moveList: async (src, dst) => invokeBoard('moveList', src, dst),
   createList: async (listPath) => invokeBoard('createList', listPath),

--- a/preload.js
+++ b/preload.js
@@ -53,7 +53,8 @@ contextBridge.exposeInMainWorld('board', {
   moveList: async (src, dst) => invokeBoard('moveList', src, dst),
   createList: async (listPath) => invokeBoard('createList', listPath),
   deleteList: async (listPath) => invokeBoard('deleteList', listPath),
-  importFromTrello: async (boardRoot) => invokeBoard('importFromTrello', boardRoot),
+  importTrello: async (boardRoot, selectionToken) => invokeBoard('importTrello', boardRoot, selectionToken),
+  importObsidian: async (boardRoot, selectionTokens) => invokeBoard('importObsidian', boardRoot, selectionTokens),
   copyExternal: async () => {
     throw new Error('UNSUPPORTED_OPERATION');
   },
@@ -61,6 +62,7 @@ contextBridge.exposeInMainWorld('board', {
 
 contextBridge.exposeInMainWorld('chooser', {
   pickDirectory: (opts = {}) => ipcRenderer.invoke('choose-directory', opts),
+  pickImportSources: (opts = {}) => ipcRenderer.invoke('pick-import-sources', opts),
 });
 
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Signboard
 
-A local-first kanban desktop app built with HTML, CSS, and JavaScript. Signboard stores your lists as directories and cards as Markdown files on disk, so you own your data.
+A local-first kanban desktop app built with HTML, CSS, and JavaScript. Signboard stores your lists as directories and cards as Markdown files on disk.
 
-Signboard is free for personal use. If you are using Signboard for your work it would be appreciated if you purchase a commercial license to support future development. See the app's "support" area.
+Signboard is free for personal use. If you are using Signboard for your work it would be appreciated if you purchase a commercial license to support future development. See the app's "support" button.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/cdevroe/signboard)](../../issues)
@@ -12,16 +12,18 @@ Signboard is free for personal use. If you are using Signboard for your work it 
 ---
 
 ## ✨ Highlights
-- 📂 Cards saved as Markdown files (portable & future-proof)
-- 🖌️ Custom color scheme per board
-- 🏷 Per-card labels with light/dark colors
-- 📅 Due dates
+- ⬇️ Import from Trello and Obsidian
+- 📂 Cards saved as Markdown files
+- 🖌️ Color scheme per board (several to choose from!)
+- 🌙 Light and dark mode variants for all color schemes
+- 🏷 Custom labels per Board
+- 🗓 Card due dates and Task list item due dates
 - 📅 Calendar and "This Week" views
-- ✅ Task progress counters on cards (`completed/total`)
-- 🗓 Per-task due dates that feed Calendar and This Week views
-- 🔎 Live search across
-- 🖥 Runs as a desktop app
-- 🪶 Minimal dependencies 😅, just plain JavaScript + Electron
+- ✅ Progress counters on cards
+- 🔎 Live search
+- ⌨️ Keyboard shortcuts
+- 🤖 MCP Server
+- 💻 CLI
 
 ---
 
@@ -36,6 +38,7 @@ Signboard is free for personal use. If you are using Signboard for your work it 
 - `Cmd/Ctrl + N`: add card
 - `Cmd/Ctrl + Shift + N`: add list
 - `Cmd/Ctrl + 1`, `2`, `3`: switch board views
+- `Cmd/Ctrl + F`: focus search field
 - `Esc`: close open modals
 - In app: `Help` -> `Keyboard Shortcuts`
 
@@ -44,12 +47,7 @@ Signboard is free for personal use. If you are using Signboard for your work it 
 Signboard includes a built-in MCP server so agents can interact with local boards.
 
 - Dedicated instructions: [MCP_README.md](./MCP_README.md)
-- Run from source: `npm run mcp:server`
-- Print ready-to-paste config JSON: `npm run mcp:config`
-- Run from packaged app: launch Signboard executable with `--mcp-server`
-- In app: `Help` -> `Copy MCP Config`
-- Board creation tool: `signboard.create_board`
-- Board-name lookup tool: `signboard.resolve_board_by_name`
+- To copy config: `Help` -> `Copy MCP Config`
 - Optional agent skill: `skills/signboard-mcp/SKILL.md`
 
 ## 💻 CLI
@@ -241,10 +239,8 @@ Contributions in all forms are welcome!
 
 Signboard now includes an in-app support modal with two options:
 
-- Personal use: free, with an optional tip in any amount.
+- Personal use: free, with an optional tip in any amount
 - Commercial use: requested one-time payment
-
-If you are using Signboard in a paid or commercial context, the app asks you to support development through that one-time payment. If you are using it for personal projects, you can keep using it for free and optionally leave a tip.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,10 @@ signboard cards create --list "To do" --title "Ship release notes" --due 2026-03
 signboard cards edit --card ab123 --due none --move-to Doing
 signboard cards read --list Doing --card ab123
 
+# Imports
+signboard import trello --file ~/Downloads/trello-export.json
+signboard import obsidian --source ~/Vault/Kanban.md --source ~/Vault/Boards/
+
 # Or run through the packaged app executable
 /Applications/Signboard.app/Contents/MacOS/Signboard use /Path/to/Board
 /Applications/Signboard.app/Contents/MacOS/Signboard cards --due next:7
@@ -100,6 +104,11 @@ Interesting card listing filters:
 - `--search <query>`
 - `--sort list|due|title|updated`
 - `--json` for scripting output
+
+Import options:
+
+- `signboard import trello --file <export.json> [--board <path>] [--json]`
+- `signboard import obsidian --source <path> [--source <path> ...] [--board <path>] [--json]`
 
 ## ✅ Task List Items
 

--- a/scripts/test-archive.js
+++ b/scripts/test-archive.js
@@ -1,0 +1,110 @@
+const assert = require('assert');
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+const { ARCHIVE_DIRECTORY_NAME, archiveCard, archiveList } = require('../lib/archive');
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function createBoardRoot(root, boardName) {
+  const boardRoot = path.join(root, boardName);
+  await fs.mkdir(boardRoot, { recursive: true });
+  return boardRoot;
+}
+
+async function testArchiveCardCreatesArchiveAndRenumbersOnCollision(root) {
+  const boardRoot = await createBoardRoot(root, 'Archive Cards Board');
+  const todoList = path.join(boardRoot, '000-To-do-stock');
+  const doingList = path.join(boardRoot, '001-Doing-stock');
+
+  await fs.mkdir(todoList, { recursive: true });
+  await fs.mkdir(doingList, { recursive: true });
+
+  const firstCardPath = path.join(todoList, '000-plan-release-stock.md');
+  const secondCardPath = path.join(doingList, '000-plan-release-stock.md');
+  await fs.writeFile(firstCardPath, '# Plan release\n', 'utf8');
+  await fs.writeFile(secondCardPath, '# Another plan\n', 'utf8');
+
+  const firstResult = await archiveCard(boardRoot, firstCardPath);
+  assert.strictEqual(firstResult.archivedCardFile, '000-plan-release-stock.md');
+  assert.strictEqual(await pathExists(path.join(boardRoot, ARCHIVE_DIRECTORY_NAME)), true);
+  assert.strictEqual(await pathExists(firstCardPath), false);
+  assert.strictEqual(
+    await pathExists(path.join(boardRoot, ARCHIVE_DIRECTORY_NAME, '000-plan-release-stock.md')),
+    true,
+  );
+
+  const secondResult = await archiveCard(boardRoot, secondCardPath);
+  assert.strictEqual(secondResult.archivedCardFile, '001-plan-release-stock.md');
+  assert.strictEqual(await pathExists(secondCardPath), false);
+  assert.strictEqual(
+    await pathExists(path.join(boardRoot, ARCHIVE_DIRECTORY_NAME, '001-plan-release-stock.md')),
+    true,
+  );
+}
+
+async function testArchiveListAddsSuffixOnCollision(root) {
+  const boardRoot = await createBoardRoot(root, 'Archive Lists Board');
+  const workingList = path.join(boardRoot, '001-Working-stock');
+  const archiveRoot = path.join(boardRoot, ARCHIVE_DIRECTORY_NAME);
+
+  await fs.mkdir(workingList, { recursive: true });
+  await fs.mkdir(path.join(archiveRoot, '001-Working-stock'), { recursive: true });
+  await fs.writeFile(path.join(workingList, '000-ship-it-stock.md'), '# Ship it\n', 'utf8');
+
+  const result = await archiveList(boardRoot, workingList);
+  assert.strictEqual(result.alreadyArchived, false);
+  assert.ok(/^001-Working-stock-[A-Za-z0-9]{5}$/.test(result.archivedDirectoryName));
+  assert.strictEqual(await pathExists(workingList), false);
+  assert.strictEqual(await pathExists(path.join(archiveRoot, result.archivedDirectoryName)), true);
+  assert.strictEqual(
+    await pathExists(path.join(archiveRoot, result.archivedDirectoryName, '000-ship-it-stock.md')),
+    true,
+  );
+}
+
+async function testAlreadyArchivedNoOps(root) {
+  const boardRoot = await createBoardRoot(root, 'Already Archived Board');
+  const archiveRoot = path.join(boardRoot, ARCHIVE_DIRECTORY_NAME);
+  const archivedList = path.join(archiveRoot, '000-Old-stock');
+  const archivedCardPath = path.join(archiveRoot, '000-old-card-stock.md');
+
+  await fs.mkdir(archivedList, { recursive: true });
+  await fs.writeFile(archivedCardPath, '# Archived card\n', 'utf8');
+
+  const archivedCardResult = await archiveCard(boardRoot, archivedCardPath);
+  assert.strictEqual(archivedCardResult.alreadyArchived, true);
+  assert.strictEqual(archivedCardResult.archivedCardPath, archivedCardPath);
+
+  const archivedListResult = await archiveList(boardRoot, archivedList);
+  assert.strictEqual(archivedListResult.alreadyArchived, true);
+  assert.strictEqual(archivedListResult.archivedListPath, archivedList);
+}
+
+async function main() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'signboard-archive-'));
+
+  try {
+    await testArchiveCardCreatesArchiveAndRenumbersOnCollision(root);
+    await testArchiveListAddsSuffixOnCollision(root);
+    await testAlreadyArchivedNoOps(root);
+    console.log('Archive tests passed.');
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message || error);
+  process.exitCode = 1;
+});

--- a/scripts/test-cli.js
+++ b/scripts/test-cli.js
@@ -46,6 +46,13 @@ function runCliExpectFail(args, env, options = {}) {
   return result;
 }
 
+function daysFromTodayIso(daysAhead) {
+  const date = new Date();
+  date.setHours(12, 0, 0, 0);
+  date.setDate(date.getDate() + Number(daysAhead || 0));
+  return date.toISOString().slice(0, 10);
+}
+
 async function createFixtureBoard() {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'signboard-cli-'));
   const boardRoot = path.join(root, 'Client Work');
@@ -68,10 +75,10 @@ async function createFixtureBoard() {
   await cardFrontmatter.writeCard(path.join(todoList, '001-launch-plan-ab123.md'), {
     frontmatter: {
       title: 'Launch plan',
-      due: '2026-03-15',
+      due: daysFromTodayIso(3),
       labels: ['urgent'],
     },
-    body: 'Prepare launch notes\n- [ ] (due: 2026-03-12) Draft email',
+    body: `Prepare launch notes\n- [ ] (due: ${daysFromTodayIso(2)}) Draft email`,
   });
 
   await cardFrontmatter.writeCard(path.join(todoList, '002-client-follow-up-cd456.md'), {
@@ -79,7 +86,7 @@ async function createFixtureBoard() {
       title: 'Client follow up',
       labels: ['client'],
     },
-    body: 'Follow up with client\n- [ ] (due: 2026-03-18) Schedule check-in',
+    body: `Follow up with client\n- [ ] (due: ${daysFromTodayIso(5)}) Schedule check-in`,
   });
 
   await cardFrontmatter.writeCard(path.join(doingList, '001-internal-review-ef789.md'), {
@@ -92,8 +99,85 @@ async function createFixtureBoard() {
   return { root, boardRoot };
 }
 
+async function createImportFixtures(root) {
+  const importsRoot = path.join(root, 'imports');
+  await fs.mkdir(importsRoot, { recursive: true });
+
+  const trelloPath = path.join(importsRoot, 'trello-export.json');
+  await fs.writeFile(trelloPath, JSON.stringify({
+    name: 'Sales Pipeline',
+    lists: [
+      { id: 'trello-list-1', name: 'Trello Leads', closed: false, pos: 1 },
+    ],
+    labels: [
+      { id: 'trello-label-1', name: 'Pipeline', color: 'green' },
+    ],
+    members: [],
+    checklists: [
+      {
+        id: 'check-1',
+        idCard: 'trello-card-1',
+        name: 'Prep',
+        pos: 1,
+        checkItems: [
+          { id: 'check-item-1', name: 'Share outline', pos: 1, state: 'incomplete' },
+        ],
+      },
+    ],
+    actions: [
+      {
+        id: 'action-1',
+        type: 'commentCard',
+        date: '2026-03-20T12:00:00.000Z',
+        data: { idCard: 'trello-card-1' },
+        memberCreator: { fullName: 'Alex Example', username: 'alex' },
+        text: 'Remember the deck.',
+      },
+    ],
+    cards: [
+      {
+        id: 'trello-card-1',
+        idList: 'trello-list-1',
+        name: 'Imported pitch',
+        desc: 'Imported from Trello.',
+        due: '2026-03-22',
+        closed: false,
+        pos: 1,
+        idLabels: ['trello-label-1'],
+        attachments: [
+          { id: 'attachment-1', name: 'Brief', url: 'https://example.com/brief' },
+        ],
+      },
+    ],
+  }, null, 2), 'utf8');
+
+  const obsidianPath = path.join(importsRoot, 'editorial-kanban.md');
+  await fs.writeFile(obsidianPath, [
+    '---',
+    'kanban-plugin: board',
+    '---',
+    '',
+    '## Inbox',
+    '- [ ] Draft intro @{2026-03-24} #Writing',
+    '',
+    '## Done',
+    '- [x] Sent final #Done',
+    '',
+    '%% kanban:settings',
+    '{"kanban-plugin":"board"}',
+    '%%',
+    '',
+  ].join('\n'), 'utf8');
+
+  return {
+    trelloPath,
+    obsidianPath,
+  };
+}
+
 async function main() {
   const fixture = await createFixtureBoard();
+  const importFixtures = await createImportFixtures(fixture.root);
   const configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'signboard-cli-config-'));
   const env = {
     SIGNBOARD_CLI_CONFIG_DIR: configDir,
@@ -231,6 +315,55 @@ async function main() {
     ], env).stdout
   );
   assert.strictEqual(doingCards[0].title, 'Needs approval');
+
+  const trelloImport = JSON.parse(
+    runCli([
+      'import',
+      'trello',
+      '--file',
+      importFixtures.trelloPath,
+      '--json',
+    ], env).stdout
+  );
+  assert.strictEqual(trelloImport.importer, 'trello');
+  assert.strictEqual(trelloImport.listsCreated, 1);
+  assert.strictEqual(trelloImport.cardsCreated, 1);
+
+  const trelloCards = JSON.parse(
+    runCli([
+      'cards',
+      '--search',
+      'Imported pitch',
+      '--json',
+    ], env).stdout
+  );
+  assert.strictEqual(trelloCards.length, 1);
+  assert.strictEqual(trelloCards[0].due, '2026-03-22');
+
+  const obsidianImport = JSON.parse(
+    runCli([
+      'import',
+      'obsidian',
+      '--source',
+      importFixtures.obsidianPath,
+      '--json',
+    ], env).stdout
+  );
+  assert.strictEqual(obsidianImport.importer, 'obsidian');
+  assert.strictEqual(obsidianImport.listsCreated, 2);
+  assert.strictEqual(obsidianImport.cardsCreated, 2);
+
+  const obsidianCards = JSON.parse(
+    runCli([
+      'cards',
+      '--search',
+      'Draft intro',
+      '--json',
+    ], env).stdout
+  );
+  assert.strictEqual(obsidianCards.length, 1);
+  assert.strictEqual(obsidianCards[0].due, '2026-03-24');
+  assert.ok(obsidianCards[0].labelNames.includes('Writing'));
 
   console.log('CLI tests passed.');
 }

--- a/scripts/test-desktop-cli.js
+++ b/scripts/test-desktop-cli.js
@@ -26,13 +26,50 @@ async function createFixtureBoard() {
   await cardFrontmatter.writeCard(path.join(todoList, '001-launch-plan-ab123.md'), {
     frontmatter: {
       title: 'Launch plan',
-      due: '2026-03-15',
+      due: daysFromTodayIso(3),
       labels: ['urgent'],
     },
-    body: 'Prepare launch notes\n- [ ] (due: 2026-03-12) Draft email',
+    body: `Prepare launch notes\n- [ ] (due: ${daysFromTodayIso(2)}) Draft email`,
   });
 
-  return { boardRoot };
+  return { root, boardRoot };
+}
+
+function daysFromTodayIso(daysAhead) {
+  const date = new Date();
+  date.setHours(12, 0, 0, 0);
+  date.setDate(date.getDate() + Number(daysAhead || 0));
+  return date.toISOString().slice(0, 10);
+}
+
+async function createImportFixtures(root) {
+  const importsRoot = path.join(root, 'imports');
+  await fs.mkdir(importsRoot, { recursive: true });
+
+  const trelloPath = path.join(importsRoot, 'desktop-cli-trello.json');
+  await fs.writeFile(trelloPath, JSON.stringify({
+    name: 'Desktop CLI Import',
+    lists: [
+      { id: 'desktop-list-1', name: 'Desktop Imported', closed: false, pos: 1 },
+    ],
+    labels: [],
+    members: [],
+    checklists: [],
+    actions: [],
+    cards: [
+      {
+        id: 'desktop-card-1',
+        idList: 'desktop-list-1',
+        name: 'Desktop imported card',
+        desc: 'Imported through Electron CLI.',
+        closed: false,
+        pos: 1,
+        idLabels: [],
+      },
+    ],
+  }, null, 2), 'utf8');
+
+  return { trelloPath };
 }
 
 function runDesktopCli(args, env = {}) {
@@ -73,6 +110,7 @@ function runDesktopCliExpectFail(args, env = {}) {
 
 async function main() {
   const fixture = await createFixtureBoard();
+  const importFixtures = await createImportFixtures(fixture.root);
   const configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'signboard-desktop-cli-config-'));
   const env = {
     SIGNBOARD_CLI_CONFIG_DIR: configDir,
@@ -106,6 +144,17 @@ async function main() {
   ], env);
   const settings = JSON.parse(settingsResult.stdout);
   assert.strictEqual(settings.tooltipsEnabled, false);
+
+  const importResult = runDesktopCli([
+    'import',
+    'trello',
+    '--file',
+    importFixtures.trelloPath,
+    '--json',
+  ], env);
+  const importSummary = JSON.parse(importResult.stdout);
+  assert.strictEqual(importSummary.importer, 'trello');
+  assert.strictEqual(importSummary.cardsCreated, 1);
 
   console.log('Desktop CLI tests passed.');
 }

--- a/scripts/test-import-obsidian.js
+++ b/scripts/test-import-obsidian.js
@@ -1,0 +1,148 @@
+const assert = require('assert');
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+
+const boardLabels = require('../lib/boardLabels');
+const cardFrontmatter = require('../lib/cardFrontmatter');
+const { importObsidian } = require('../lib/importers');
+const { ARCHIVE_DIRECTORY_NAME, getListDisplayName } = require('../lib/cliBoard');
+
+async function listDirectories(boardRoot) {
+  const entries = await fs.readdir(boardRoot, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+}
+
+async function listMarkdownFiles(directoryPath) {
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+  return entries.filter((entry) => entry.isFile() && entry.name.endsWith('.md')).map((entry) => entry.name).sort();
+}
+
+async function run() {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'signboard-import-obsidian-'));
+  const boardRoot = path.join(tmpDir, 'Imported Board');
+  const kanbanFile = path.join(tmpDir, 'Roadmap.md');
+  const taskScopeDir = path.join(tmpDir, 'TaskScope');
+  const cardBoardVault = path.join(tmpDir, 'Vault');
+  const todayIso = new Date().toISOString().slice(0, 10);
+  await fs.mkdir(boardRoot, { recursive: true });
+  await fs.mkdir(taskScopeDir, { recursive: true });
+  await fs.mkdir(path.join(cardBoardVault, '.obsidian', 'plugins', 'card-board'), { recursive: true });
+
+  try {
+    await boardLabels.writeBoardSettings(boardRoot, {
+      labels: [
+        { id: 'launch-existing', name: 'launch', colorLight: '#fb923c', colorDark: '#f97316' },
+      ],
+      notifications: { enabled: false, time: '09:00' },
+      tooltipsEnabled: true,
+    });
+
+    await fs.writeFile(kanbanFile, [
+      '---',
+      'kanban-plugin: board',
+      '---',
+      '',
+      '## To Do',
+      '',
+      `- [ ] Launch prep #launch @{2026-05-03}`,
+      '',
+      '## Doing',
+      '',
+      '- [ ] Shipping copy #content',
+      '',
+      '%% kanban:settings',
+      '```',
+      '{"kanban-plugin":"board"}',
+      '```',
+      '%%',
+    ].join('\n'), 'utf8');
+
+    await fs.writeFile(path.join(taskScopeDir, 'tasks.md'), [
+      '- [ ] Capture screenshots #[Backlog] #launch',
+      '- [ ] Polish headline #[Doing] #content',
+      '- [x] Archive notes #[Done] #content',
+    ].join('\n'), 'utf8');
+
+    await fs.writeFile(path.join(cardBoardVault, '.obsidian', 'plugins', 'card-board', 'data.json'), JSON.stringify({
+      boards: [
+        {
+          name: 'Daily Board',
+          columns: [
+            { name: 'Today', type: 'between', from: 0, to: 0 },
+            { name: 'Undated', type: 'undated' },
+            { name: 'Completed', type: 'completed' },
+          ],
+        },
+      ],
+    }, null, 2), 'utf8');
+
+    await fs.writeFile(path.join(cardBoardVault, 'daily.md'), [
+      `- [ ] Ship to beta @due(${todayIso}) #launch`,
+      '- [ ] Write changelog',
+      `- [x] Sent announcement @due(${todayIso}) #launch @completed(${todayIso}T09:00:00)`,
+    ].join('\n'), 'utf8');
+
+    const summary = await importObsidian({
+      boardRoot,
+      sourcePaths: [kanbanFile, taskScopeDir, cardBoardVault],
+    });
+
+    assert.strictEqual(summary.ok, true);
+    assert.strictEqual(summary.importer, 'obsidian');
+    assert.strictEqual(summary.cardsCreated, 8);
+    assert.strictEqual(summary.listsCreated, 8);
+
+    const directoryNames = await listDirectories(boardRoot);
+    assert(!directoryNames.includes(ARCHIVE_DIRECTORY_NAME), 'obsidian import should not create archive by default');
+    const displayNames = directoryNames.map((name) => getListDisplayName(name)).sort();
+    assert(displayNames.includes('Roadmap - To Do'));
+    assert(displayNames.includes('Roadmap - Doing'));
+    assert(displayNames.includes('TaskScope - Backlog'));
+    assert(displayNames.includes('TaskScope - Doing'));
+    assert(displayNames.includes('TaskScope - Done'));
+    assert(displayNames.includes('Daily Board - Today'));
+    assert(displayNames.includes('Daily Board - Undated'));
+    assert(displayNames.includes('Daily Board - Completed'));
+
+    const settings = await boardLabels.readBoardSettings(boardRoot, { ensureFile: false });
+    const labelNames = settings.labels.map((label) => label.name).sort();
+    assert.deepStrictEqual(labelNames, ['content', 'launch']);
+
+    const roadmapTodoDir = directoryNames.find((name) => getListDisplayName(name) === 'Roadmap - To Do');
+    const roadmapTodoFiles = await listMarkdownFiles(path.join(boardRoot, roadmapTodoDir));
+    const roadmapCard = await cardFrontmatter.readCard(path.join(boardRoot, roadmapTodoDir, roadmapTodoFiles[0]));
+    assert.strictEqual(roadmapCard.frontmatter.title, 'Launch prep');
+    assert.strictEqual(roadmapCard.frontmatter.due, '2026-05-03');
+    assert.deepStrictEqual(roadmapCard.frontmatter.labels, ['launch-existing']);
+    assert(roadmapCard.body.includes('Source board'));
+
+    const taskDoingDir = directoryNames.find((name) => getListDisplayName(name) === 'TaskScope - Doing');
+    const taskDoingFiles = await listMarkdownFiles(path.join(boardRoot, taskDoingDir));
+    const taskDoingCard = await cardFrontmatter.readCard(path.join(boardRoot, taskDoingDir, taskDoingFiles[0]));
+    assert.strictEqual(taskDoingCard.frontmatter.title, 'Polish headline');
+    assert(taskDoingCard.body.includes('Source column'));
+
+    const cardBoardTodayDir = directoryNames.find((name) => getListDisplayName(name) === 'Daily Board - Today');
+    const todayFiles = await listMarkdownFiles(path.join(boardRoot, cardBoardTodayDir));
+    const todayCard = await cardFrontmatter.readCard(path.join(boardRoot, cardBoardTodayDir, todayFiles[0]));
+    assert.strictEqual(todayCard.frontmatter.title, 'Ship to beta');
+    assert.strictEqual(todayCard.frontmatter.due, todayIso);
+
+    const cardBoardCompletedDir = directoryNames.find((name) => getListDisplayName(name) === 'Daily Board - Completed');
+    const completedFiles = await listMarkdownFiles(path.join(boardRoot, cardBoardCompletedDir));
+    const completedCard = await cardFrontmatter.readCard(path.join(boardRoot, cardBoardCompletedDir, completedFiles[0]));
+    assert.strictEqual(completedCard.frontmatter.title, 'Sent announcement');
+    assert(completedCard.body.includes('Obsidian CardBoard'));
+
+    console.log('Obsidian importer tests passed.');
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+run().catch((error) => {
+  console.error('Obsidian importer tests failed.');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/test-import-trello.js
+++ b/scripts/test-import-trello.js
@@ -1,0 +1,178 @@
+const assert = require('assert');
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+
+const boardLabels = require('../lib/boardLabels');
+const cardFrontmatter = require('../lib/cardFrontmatter');
+const { importTrello } = require('../lib/importers');
+const { ARCHIVE_DIRECTORY_NAME, getListDisplayName } = require('../lib/cliBoard');
+
+async function listDirectories(boardRoot) {
+  const entries = await fs.readdir(boardRoot, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+}
+
+async function listMarkdownFiles(directoryPath) {
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+  return entries.filter((entry) => entry.isFile() && entry.name.endsWith('.md')).map((entry) => entry.name).sort();
+}
+
+async function run() {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'signboard-import-trello-'));
+  const boardRoot = path.join(tmpDir, 'Imported Board');
+  const sourcePath = path.join(tmpDir, 'trello.json');
+  await fs.mkdir(boardRoot, { recursive: true });
+
+  try {
+    await boardLabels.writeBoardSettings(boardRoot, {
+      labels: [
+        { id: 'quoted-existing', name: 'Quoted', colorLight: '#f59e0b', colorDark: '#d97706' },
+      ],
+      notifications: { enabled: false, time: '09:00' },
+      tooltipsEnabled: true,
+    });
+
+    const sourceData = {
+      name: 'Trello Demo',
+      url: 'https://trello.example/board',
+      lists: [
+        { id: 'list-open-1', name: 'Backlog', pos: 10, closed: false },
+        { id: 'list-open-2', name: 'Doing', pos: 20, closed: false },
+        { id: 'list-closed', name: 'Done Elsewhere', pos: 30, closed: true },
+      ],
+      labels: [
+        { id: 'label-reuse', name: 'Quoted', color: 'yellow' },
+        { id: 'label-blank', name: '', color: 'blue' },
+      ],
+      members: [
+        { id: 'member-1', fullName: 'Casey Example', username: 'casey' },
+      ],
+      cards: [
+        {
+          id: 'card-open',
+          idShort: 11,
+          shortLink: 'abcde',
+          idList: 'list-open-1',
+          name: 'Open Trello Card',
+          desc: 'Body from Trello',
+          due: '2026-04-02T15:00:00.000Z',
+          dueReminder: 60,
+          start: '2026-04-01T12:00:00.000Z',
+          dueComplete: false,
+          closed: false,
+          isTemplate: false,
+          pos: 10,
+          idLabels: ['label-reuse', 'label-blank'],
+          idMembers: ['member-1'],
+          attachments: [
+            { name: 'spec.txt', url: 'https://trello.example/spec.txt', mimeType: 'text/plain', bytes: 128 },
+          ],
+        },
+        {
+          id: 'card-closed',
+          idShort: 12,
+          shortLink: 'fghij',
+          idList: 'list-open-2',
+          name: 'Closed Trello Card',
+          desc: '',
+          closed: true,
+          pos: 20,
+          idLabels: [],
+          attachments: [],
+        },
+        {
+          id: 'card-from-closed-list',
+          idShort: 13,
+          shortLink: 'klmno',
+          idList: 'list-closed',
+          name: 'Card in Closed List',
+          desc: '',
+          closed: false,
+          pos: 30,
+          idLabels: [],
+          attachments: [],
+        },
+      ],
+      checklists: [
+        {
+          id: 'check-1',
+          idCard: 'card-open',
+          name: 'Checklist',
+          pos: 5,
+          checkItems: [
+            { id: 'item-1', name: 'First task', state: 'incomplete', pos: 1, due: '2026-04-05T10:00:00.000Z' },
+            { id: 'item-2', name: 'Second task', state: 'complete', pos: 2, due: null },
+          ],
+        },
+      ],
+      actions: Array.from({ length: 1000 }, (_, index) => ({
+        type: 'commentCard',
+        date: `2026-04-01T12:${String(index % 60).padStart(2, '0')}:00.000Z`,
+        data: {
+          idCard: 'card-open',
+          text: index === 0 ? 'First import comment' : `History comment ${index}`,
+        },
+        memberCreator: { fullName: 'Casey Example', username: 'casey' },
+      })),
+    };
+
+    await fs.writeFile(sourcePath, JSON.stringify(sourceData, null, 2), 'utf8');
+
+    const summary = await importTrello({
+      boardRoot,
+      sourcePath,
+    });
+
+    assert.strictEqual(summary.ok, true);
+    assert.strictEqual(summary.importer, 'trello');
+    assert.strictEqual(summary.listsCreated, 2);
+    assert.strictEqual(summary.cardsCreated, 3);
+    assert.strictEqual(summary.labelsCreated, 1);
+    assert.strictEqual(summary.archivedCards, 2);
+    assert(summary.warnings.some((warning) => warning.includes('1000 actions')), 'expected truncation warning');
+
+    const settings = await boardLabels.readBoardSettings(boardRoot, { ensureFile: false });
+    const labelNames = settings.labels.map((label) => label.name).sort();
+    assert.deepStrictEqual(labelNames, ['Quoted', 'Trello Blue']);
+
+    const directoryNames = await listDirectories(boardRoot);
+    assert(directoryNames.includes(ARCHIVE_DIRECTORY_NAME), 'archive directory should exist');
+    const visibleListNames = directoryNames
+      .filter((name) => name !== ARCHIVE_DIRECTORY_NAME)
+      .map((name) => getListDisplayName(name))
+      .sort();
+    assert.deepStrictEqual(visibleListNames, ['Backlog', 'Doing']);
+
+    const backlogDirectory = directoryNames.find((name) => getListDisplayName(name) === 'Backlog');
+    const backlogFiles = await listMarkdownFiles(path.join(boardRoot, backlogDirectory));
+    assert.strictEqual(backlogFiles.length, 1);
+    const openCard = await cardFrontmatter.readCard(path.join(boardRoot, backlogDirectory, backlogFiles[0]));
+    assert.strictEqual(openCard.frontmatter.title, 'Open Trello Card');
+    assert.strictEqual(openCard.frontmatter.due, '2026-04-02');
+    assert.deepStrictEqual(openCard.frontmatter.labels.sort(), ['quoted-existing', settings.labels.find((label) => label.name === 'Trello Blue').id].sort());
+    assert(openCard.body.includes('Body from Trello'));
+    assert(openCard.body.includes('## Checklist'));
+    assert(openCard.body.includes('- [ ] (due: 2026-04-05) First task'));
+    assert(openCard.body.includes('## Imported comments'));
+    assert(openCard.body.includes('First import comment'));
+    assert(openCard.body.includes('## Imported attachments'));
+    assert(openCard.body.includes('[spec.txt](https://trello.example/spec.txt)'));
+    assert(openCard.body.includes('Original Trello list'));
+
+    const archiveFiles = await listMarkdownFiles(path.join(boardRoot, ARCHIVE_DIRECTORY_NAME));
+    assert.strictEqual(archiveFiles.length, 2);
+    const archivedCard = await cardFrontmatter.readCard(path.join(boardRoot, ARCHIVE_DIRECTORY_NAME, archiveFiles[0]));
+    assert(archivedCard.body.includes('Closed in Trello'), 'archived cards should record closed state');
+
+    console.log('Trello importer tests passed.');
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+run().catch((error) => {
+  console.error('Trello importer tests failed.');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/test-mcp-server.js
+++ b/scripts/test-mcp-server.js
@@ -116,6 +116,56 @@ async function createFixtureBoard() {
     'utf8',
   );
 
+  const trelloImportPath = path.join(root, 'mcp-trello-import.json');
+  await fs.writeFile(
+    trelloImportPath,
+    JSON.stringify({
+      name: 'MCP Trello Import',
+      lists: [
+        { id: 'mcp-trello-list-1', name: 'Trello MCP', closed: false, pos: 1 },
+      ],
+      labels: [],
+      members: [],
+      checklists: [],
+      actions: [],
+      cards: [
+        {
+          id: 'mcp-trello-card-1',
+          idList: 'mcp-trello-list-1',
+          name: 'Imported via MCP',
+          desc: 'Created through signboard.import_trello.',
+          due: '2026-03-30',
+          closed: false,
+          pos: 1,
+          idLabels: [],
+        },
+      ],
+    }, null, 2),
+    'utf8',
+  );
+
+  const obsidianImportPath = path.join(root, 'mcp-obsidian-import.md');
+  await fs.writeFile(
+    obsidianImportPath,
+    [
+      '---',
+      'kanban-plugin: board',
+      '---',
+      '',
+      '## Inbox',
+      '- [ ] MCP draft @{2026-03-29} #MCP',
+      '',
+      '## Review',
+      '- [ ] MCP review',
+      '',
+      '%% kanban:settings',
+      '{"kanban-plugin":"board"}',
+      '%%',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+
   return {
     cleanupRoot: root,
     allowedRoot: root,
@@ -126,6 +176,8 @@ async function createFixtureBoard() {
     archiveList,
     templateCardFile,
     workingCardFile,
+    trelloImportPath,
+    obsidianImportPath,
   };
 }
 
@@ -261,6 +313,8 @@ async function runForTransport(transportMode, fixture) {
     'signboard.move_board',
     'signboard.read_board_settings',
     'signboard.update_board_settings',
+    'signboard.import_trello',
+    'signboard.import_obsidian',
   ];
 
   for (const toolName of requiredToolNames) {
@@ -471,6 +525,90 @@ async function runForTransport(transportMode, fixture) {
   }
   if (!thisWeekView || !/task due-date markers/i.test(String(thisWeekView.description || ''))) {
     throw new Error(`this-week view description missing task due markers (${transportMode}): ${JSON.stringify(thisWeekView)}`);
+  }
+
+  send({
+    jsonrpc: '2.0',
+    id: 71,
+    method: 'tools/call',
+    params: {
+      name: 'signboard.import_trello',
+      arguments: {
+        boardRoot: fixture.boardRoot,
+        sourcePath: fixture.trelloImportPath,
+      },
+    },
+  });
+
+  const trelloImportResponse = await waitForResponse(71);
+  if (trelloImportResponse.error) {
+    throw new Error(`import_trello failed (${transportMode}): ${JSON.stringify(trelloImportResponse.error)}`);
+  }
+
+  const trelloImportOutput = trelloImportResponse.result?.structuredContent || {};
+  if (trelloImportOutput.importer !== 'trello' || trelloImportOutput.listsCreated !== 1 || trelloImportOutput.cardsCreated !== 1) {
+    throw new Error(`import_trello summary mismatch (${transportMode}): ${JSON.stringify(trelloImportOutput)}`);
+  }
+
+  const boardEntriesAfterTrello = await fs.readdir(fixture.boardRoot, { withFileTypes: true });
+  const trelloImportedList = boardEntriesAfterTrello.find((entry) => entry.isDirectory() && /-Trello MCP-/.test(entry.name));
+  if (!trelloImportedList) {
+    throw new Error(`import_trello did not create the expected list (${transportMode}).`);
+  }
+
+  const trelloImportedCards = await fs.readdir(path.join(fixture.boardRoot, trelloImportedList.name));
+  if (trelloImportedCards.length !== 1) {
+    throw new Error(`import_trello created an unexpected card count (${transportMode}): ${JSON.stringify(trelloImportedCards)}`);
+  }
+
+  const trelloImportedCardBody = await fs.readFile(
+    path.join(fixture.boardRoot, trelloImportedList.name, trelloImportedCards[0]),
+    'utf8',
+  );
+  if (!trelloImportedCardBody.includes('title: Imported via MCP') || !trelloImportedCardBody.includes('due: 2026-03-30')) {
+    throw new Error(`import_trello card content mismatch (${transportMode}): ${trelloImportedCardBody}`);
+  }
+
+  send({
+    jsonrpc: '2.0',
+    id: 72,
+    method: 'tools/call',
+    params: {
+      name: 'signboard.import_obsidian',
+      arguments: {
+        boardRoot: fixture.boardRoot,
+        sourcePaths: [fixture.obsidianImportPath],
+      },
+    },
+  });
+
+  const obsidianImportResponse = await waitForResponse(72);
+  if (obsidianImportResponse.error) {
+    throw new Error(`import_obsidian failed (${transportMode}): ${JSON.stringify(obsidianImportResponse.error)}`);
+  }
+
+  const obsidianImportOutput = obsidianImportResponse.result?.structuredContent || {};
+  if (obsidianImportOutput.importer !== 'obsidian' || obsidianImportOutput.listsCreated !== 2 || obsidianImportOutput.cardsCreated !== 2) {
+    throw new Error(`import_obsidian summary mismatch (${transportMode}): ${JSON.stringify(obsidianImportOutput)}`);
+  }
+
+  const boardEntriesAfterObsidian = await fs.readdir(fixture.boardRoot, { withFileTypes: true });
+  const obsidianImportedList = boardEntriesAfterObsidian.find((entry) => entry.isDirectory() && /-Inbox-/.test(entry.name));
+  if (!obsidianImportedList) {
+    throw new Error(`import_obsidian did not create the expected Inbox list (${transportMode}).`);
+  }
+
+  const obsidianImportedCards = await fs.readdir(path.join(fixture.boardRoot, obsidianImportedList.name));
+  if (obsidianImportedCards.length !== 1) {
+    throw new Error(`import_obsidian created an unexpected Inbox card count (${transportMode}): ${JSON.stringify(obsidianImportedCards)}`);
+  }
+
+  const obsidianImportedCardBody = await fs.readFile(
+    path.join(fixture.boardRoot, obsidianImportedList.name, obsidianImportedCards[0]),
+    'utf8',
+  );
+  if (!obsidianImportedCardBody.includes('title: MCP draft') || !obsidianImportedCardBody.includes('due: 2026-03-29')) {
+    throw new Error(`import_obsidian card content mismatch (${transportMode}): ${obsidianImportedCardBody}`);
   }
 
   send({

--- a/static/styles.css
+++ b/static/styles.css
@@ -983,21 +983,29 @@ body.board-empty main#board {
   color: var(--text);
 }
 
-/* Add-card button shown in list headers */
-.btnOpenAddCardModal {
+/* List actions button shown in list headers */
+.list-actions-button {
   background: var(--bg-card);
   color: var(--text);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 6px 10px;
-  font-weight: 700;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   box-shadow: 0 1px 0 rgba(0,0,0,.02);
 }
-.btnOpenAddCardModal:hover {
+.list-actions-button svg {
+  width: 16px;
+  height: 16px;
+}
+.list-actions-button:hover {
   background: color-mix(in oklab, var(--bg-card) 94%, var(--border));
 }
-.btnOpenAddCardModal:focus-visible {
+.list-actions-button:focus-visible {
   outline: 3px solid color-mix(in oklab, var(--accent) 45%, var(--bg-card));
 }
 
@@ -2205,6 +2213,15 @@ button:focus-visible { outline: 3px solid color-mix(in oklab, var(--accent) 45%,
   z-index: 11000;
 }
 
+.list-actions-popover {
+  position: fixed;
+  z-index: 11010;
+  min-width: 210px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .label-popover-row {
   display: flex;
   align-items: center;
@@ -2281,6 +2298,37 @@ button:focus-visible { outline: 3px solid color-mix(in oklab, var(--accent) 45%,
 .label-popover-clear {
   margin-top: 8px;
   width: 100%;
+}
+
+.list-actions-option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  box-shadow: none;
+  font-size: var(--font-sm);
+  font-weight: 500;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.list-actions-option:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--bg-card) 86%, var(--border));
+}
+
+.list-actions-option:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.list-actions-option-destructive {
+  color: color-mix(in oklab, #dc2626 72%, var(--text));
+}
+
+.list-actions-option-destructive:hover:not(:disabled) {
+  background: color-mix(in oklab, #dc2626 12%, transparent);
 }
 
 #modalEditCard #cardEditorCardID { cursor: pointer; margin-top: 10px; float: right; font-size: var(--font-sm); color: var(--muted); }

--- a/static/styles.css
+++ b/static/styles.css
@@ -2033,6 +2033,22 @@ button:focus-visible { outline: 3px solid color-mix(in oklab, var(--accent) 45%,
   height: 15px;
 }
 
+.board-color-scheme-selector {
+  margin-bottom: 12px;
+}
+
+.board-color-scheme-selector select {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: var(--font-sm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--text);
+  cursor: pointer;
+  appearance: auto;
+}
+
 .board-theme-settings-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2051,28 +2067,6 @@ button:focus-visible { outline: 3px solid color-mix(in oklab, var(--accent) 45%,
 .board-theme-settings-mode h4 {
   margin: 0;
   font-size: var(--font-sm);
-}
-
-.board-theme-settings-mode label {
-  color: var(--muted);
-  font-size: var(--font-xs);
-  text-transform: uppercase;
-  letter-spacing: .04em;
-}
-
-.board-theme-settings-mode input[type="color"] {
-  width: 100%;
-  height: 38px;
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  cursor: pointer;
-}
-
-.board-theme-picker-hint {
-  margin: 0;
-  color: var(--muted);
-  font-size: var(--font-xs);
 }
 
 .board-theme-preview {
@@ -2104,15 +2098,6 @@ button:focus-visible { outline: 3px solid color-mix(in oklab, var(--accent) 45%,
   font-size: var(--font-xs);
   padding: 4px 8px;
   box-shadow: none;
-}
-
-.board-theme-warning {
-  margin-top: 10px;
-  color: #b45309;
-}
-
-:root[data-theme="dark"] .board-theme-warning {
-  color: #fbbf24;
 }
 
 .board-theme-settings-actions {

--- a/static/styles.css
+++ b/static/styles.css
@@ -1862,6 +1862,41 @@ button:focus-visible { outline: 3px solid color-mix(in oklab, var(--accent) 45%,
   letter-spacing: .04em;
 }
 
+.board-import-option {
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in oklab, var(--bg-card) 96%, var(--border));
+}
+
+.board-import-option h4 {
+  margin: 0 0 4px 0;
+}
+
+.board-import-status,
+.board-import-warnings {
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: var(--radius);
+  font-size: var(--font-sm);
+}
+
+.board-import-status {
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--bg-card) 92%, var(--accent) 8%);
+}
+
+.board-import-warnings {
+  border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border));
+  background: color-mix(in oklab, var(--bg-card) 90%, var(--accent) 10%);
+}
+
+.board-import-warnings p,
+.board-import-status p {
+  margin: 0;
+}
+
 .board-settings-inline-actions {
   display: flex;
   gap: 8px;

--- a/tests/playwright/signboard-smoke.spec.js
+++ b/tests/playwright/signboard-smoke.spec.js
@@ -257,6 +257,40 @@ test('persists the board tooltip toggle and suppresses tooltips when disabled', 
   }).toBe(false);
 });
 
+test('persists a label color change committed from the board settings picker', async ({ page }) => {
+  await page.locator('#openBoardSettings').click();
+  await expect(page.locator('#modalBoardSettings')).toBeVisible();
+  await page.locator('#boardSettingsNavLabels').click();
+
+  const labelColorInput = page.locator('#boardSettingsLabels input[type="color"]').first();
+  await expect(labelColorInput).toHaveValue('#fb923c');
+  const expectedDarkColor = await page.evaluate(() => {
+    return createReadableLabelColors('#0ea5e9', '#fb923c').colorDark;
+  });
+
+  await labelColorInput.evaluate((element) => {
+    element.value = '#0ea5e9';
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+
+  await page.locator('#boardSettingsClose').click();
+  await expect(page.locator('#modalBoardSettings')).toBeHidden();
+
+  await expect.poll(async () => {
+    return await page.evaluate(async () => {
+      const settings = await window.board.readBoardSettings(window.boardRoot);
+      return settings.labels[0].colorLight;
+    });
+  }).toBe('#0ea5e9');
+
+  await expect.poll(async () => {
+    return await page.evaluate(async () => {
+      const settings = await window.board.readBoardSettings(window.boardRoot);
+      return settings.labels[0].colorDark;
+    });
+  }).toBe(expectedDarkColor);
+});
+
 test('shows import controls and renders an import summary from the Board Settings import panel', async ({ page }) => {
   await page.evaluate(() => {
     window.__signboardImportOverrides = {

--- a/tests/playwright/signboard-smoke.spec.js
+++ b/tests/playwright/signboard-smoke.spec.js
@@ -18,6 +18,18 @@ function getShortcut(shortcut) {
   return `${modifier}+${shortcut}`;
 }
 
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
 async function seedBoardState(page, boardRoot) {
   const normalizedBoardRoot = normalizeBoardRoot(boardRoot);
 
@@ -98,14 +110,72 @@ test('keeps add modals hidden on startup', async ({ page }) => {
   await expect(page.locator('#modalAddList')).toBeHidden();
 });
 
-test('opens the list add-card modal from the inline plus button with visible spacing', async ({ page }) => {
-  await page.locator('.btnOpenAddCardModal').first().click();
+test('opens the list actions popover and routes Add new card through the existing modal', async ({ page }) => {
+  await page.locator('.list-actions-button').first().click();
 
+  await expect(page.locator('#listActionsPopover')).toBeVisible();
+  await expect(page.locator('#listActionsPopover')).toContainText('Add new card');
+  await expect(page.locator('#listActionsPopover')).toContainText('Archive cards in this list');
+  await expect(page.locator('#listActionsPopover')).toContainText('Archive this list');
+
+  await page.locator('#listActionsPopover').getByRole('button', { name: 'Add new card' }).click();
+
+  await expect(page.locator('#listActionsPopover')).toBeHidden();
   await expect(page.locator('#modalAddCard')).toBeVisible();
   await expect(page.locator('#hiddenListPath')).toHaveValue(/000-To-do-stock\/$/);
 
   const gap = await getVerticalGap(page.locator('#userInput'), page.locator('#btnAddCard'));
   expect(gap).toBeGreaterThanOrEqual(6);
+});
+
+test('archives all cards in a list from the list actions popover', async ({ page, boardRoot }) => {
+  await page.evaluate(() => {
+    window.__lastArchiveConfirmMessage = '';
+    window.confirm = (message) => {
+      window.__lastArchiveConfirmMessage = String(message || '');
+      return true;
+    };
+  });
+
+  await page.locator('.list-actions-button').first().click();
+  await page.locator('#listActionsPopover').getByRole('button', { name: 'Archive cards in this list' }).click();
+
+  await expect.poll(async () => {
+    return await page.evaluate(() => window.__lastArchiveConfirmMessage);
+  }).toContain('Archive all cards in "To-do"?');
+
+  await expect(page.locator('#listActionsPopover')).toBeHidden();
+  await expect(page.locator('.list').first().locator('.card')).toHaveCount(0);
+
+  await expect.poll(async () => {
+    const entries = await fs.readdir(path.join(boardRoot, '000-To-do-stock'));
+    return entries.filter((entry) => entry.endsWith('.md')).length;
+  }).toBe(0);
+
+  await expect.poll(async () => {
+    return await pathExists(path.join(boardRoot, 'XXX-Archive', '000-plan-release-stock.md'));
+  }).toBe(true);
+});
+
+test('archives a whole list from the list actions popover', async ({ page, boardRoot }) => {
+  await page.locator('.list-actions-button').nth(1).click();
+  await page.locator('#listActionsPopover').getByRole('button', { name: 'Archive this list' }).click();
+
+  await expect(page.locator('#listActionsPopover')).toBeHidden();
+  await expect(page.locator('.list')).toHaveCount(2);
+  await expect(page.locator('.list').filter({ hasText: 'Doing' })).toHaveCount(0);
+
+  await expect.poll(async () => {
+    return await pathExists(path.join(boardRoot, '001-Doing-stock'));
+  }).toBe(false);
+
+  await expect.poll(async () => {
+    return await pathExists(path.join(boardRoot, 'XXX-Archive', '001-Doing-stock'));
+  }).toBe(true);
+
+  await expect.poll(async () => {
+    return await pathExists(path.join(boardRoot, 'XXX-Archive', '001-Doing-stock', '000-polish-copy-stock.md'));
+  }).toBe(true);
 });
 
 test('opens the add-card-to-list modal from the keyboard shortcut with a styled dropdown', async ({ page }) => {

--- a/tests/playwright/signboard-smoke.spec.js
+++ b/tests/playwright/signboard-smoke.spec.js
@@ -186,3 +186,37 @@ test('persists the board tooltip toggle and suppresses tooltips when disabled', 
     });
   }).toBe(false);
 });
+
+test('shows import controls and renders an import summary from the Board Settings import panel', async ({ page }) => {
+  await page.evaluate(() => {
+    window.__signboardImportOverrides = {
+      pickImportSources: async () => ([
+        { token: 'trello-token', path: '/tmp/example.json', kind: 'file' },
+      ]),
+      importTrello: async () => ({
+        ok: true,
+        importer: 'trello',
+        sources: ['/tmp/example.json'],
+        listsCreated: 2,
+        cardsCreated: 3,
+        labelsCreated: 1,
+        archivedCards: 1,
+        warnings: ['Imported comments may be incomplete.'],
+      }),
+    };
+  });
+
+  await page.locator('#openBoardSettings').click();
+  await expect(page.locator('#modalBoardSettings')).toBeVisible();
+  await page.locator('#boardSettingsNavImport').click();
+
+  await expect(page.locator('#boardSettingsPanelImport')).toBeVisible();
+  await expect(page.locator('#btnImportBoardFromTrello')).toBeVisible();
+  await expect(page.locator('#btnImportBoardFromObsidian')).toBeVisible();
+
+  await page.locator('#btnImportBoardFromTrello').click();
+
+  await expect(page.locator('#boardSettingsImportStatus')).toContainText('Imported 1 source.');
+  await expect(page.locator('#boardSettingsImportStatus')).toContainText('2 lists created.');
+  await expect(page.locator('#boardSettingsImportWarnings')).toContainText('Imported comments may be incomplete.');
+});


### PR DESCRIPTION
- Added Trello and Obsidian import support in the desktop app, CLI, and MCP
- Lists can be archived
- All cards on a list can be archived at once
- Added a list of curated color schemes for boards (give them a try!)
- Added a keyboard shortcut to focus board search with Cmd/Ctrl + F.
- Fixed an issue with the label color picker.
- Other fixes and improvements